### PR TITLE
Run prettier and eslint over all files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
                   node-version: ${{ matrix.node-version }}
             - name: Install dependencies
               run: npm ci
+            - name: Check linter
+              run: npm run lint:prettier
             - name: Build Fore
               run: npm run build
             - name: Run tests

--- a/demo/ultra-lazy.html
+++ b/demo/ultra-lazy.html
@@ -53,15 +53,15 @@
 <script type="module" src="../index.js"></script>
 <script>
     const form = document.querySelector('fx-form');
-    form.addEventListener('refresh-done', function(e) {
-        const inst = form.model.getDefaultInstanceData();
-        const ser = new XMLSerializer();
-        const serialized = ser.serializeToString(inst);
-        console.log('default inst ', ser.serializeToString(inst));
-        const tmpl = document.getElementById('debug');
-        console.log('debug ', tmpl);
-        tmpl.innerHTML = serialized;
-    });
+    form.addEventListener('refresh-done', (e) => {
+    const inst = form.model.getDefaultInstanceData();
+    const ser = new XMLSerializer();
+    const serialized = ser.serializeToString(inst);
+    console.log('default inst ', ser.serializeToString(inst));
+    const tmpl = document.getElementById('debug');
+    console.log('debug ', tmpl);
+    tmpl.innerHTML = serialized;
+});
 </script>
 </body>
 </html>

--- a/es-dev-server.config.js
+++ b/es-dev-server.config.js
@@ -1,29 +1,29 @@
 module.exports = {
-    port: 8090,
-    watch: true,
-    nodeResolve: true,
-    appIndex: './index.html',
-    plugins: [
-        {
-            serve(context){
-                console.log('context path ', context);
-                if (context.originalUrl == '/submission1'){
-                    // console.log('>>>> context ', context);
-                    context.response.status = 200;
-                    return {body:'<data></data>', type:'xml'};
-                }
-                if (context.originalUrl == '/submission2'){
-                    // console.log('>>>> context ', context);
-                    context.response.status = 200;
-                    return {body:'<data><greeting>Hi from response</greeting></data>', type:'xml'};
-                }
-                if (context.originalUrl == '/submissionfails'){
-                    // console.log('>>>> context ', context);
-                    context.response.status = 200;
-                    return {body:'<data>', type:'xml'};
-                }
-            }
+  port: 8090,
+  watch: true,
+  nodeResolve: true,
+  appIndex: './index.html',
+  plugins: [
+    {
+      serve(context) {
+        console.log('context path ', context);
+        if (context.originalUrl == '/submission1') {
+          // console.log('>>>> context ', context);
+          context.response.status = 200;
+          return { body: '<data></data>', type: 'xml' };
         }
-    ],
-    moduleDirs: ['node_modules', 'web_modules'],
+        if (context.originalUrl == '/submission2') {
+          // console.log('>>>> context ', context);
+          context.response.status = 200;
+          return { body: '<data><greeting>Hi from response</greeting></data>', type: 'xml' };
+        }
+        if (context.originalUrl == '/submissionfails') {
+          // console.log('>>>> context ', context);
+          context.response.status = 200;
+          return { body: '<data>', type: 'xml' };
+        }
+      },
+    },
+  ],
+  moduleDirs: ['node_modules', 'web_modules'],
 };

--- a/index.js
+++ b/index.js
@@ -26,5 +26,3 @@ import './src/actions/fx-message.js';
 import './src/actions/fx-setvalue.js';
 import './src/actions/fx-send.js';
 import './src/actions/fx-toggle.js';
-
-

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,38 +1,34 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const {createDefaultConfig} = require('@open-wc/testing-karma');
+const { createDefaultConfig } = require('@open-wc/testing-karma');
 const merge = require('deepmerge');
 
 // Run the tests headless by doing `npm run test --headless`
 const headless = process.env.npm_config_headless;
 
 module.exports = config => {
-    config.set(
-        merge(createDefaultConfig(config), {
-            files: [
-                // runs all files ending with .test in the test folder,
-                // can be overwritten by passing a --grep flag. examples:
-                //
-                // npm run test -- --grep test/foo/bar.test.js
-                // npm run test -- --grep test/bar/*
-                {pattern: config.grep ? config.grep : 'test/**/*.test.js', type: 'module'},
-            ],
+  config.set(
+    merge(createDefaultConfig(config), {
+      files: [
+        // runs all files ending with .test in the test folder,
+        // can be overwritten by passing a --grep flag. examples:
+        //
+        // npm run test -- --grep test/foo/bar.test.js
+        // npm run test -- --grep test/bar/*
+        { pattern: config.grep ? config.grep : 'test/**/*.test.js', type: 'module' },
+      ],
 
-            esm: {
-                nodeResolve: true,
-            },
-            browserDisconnectTimeout: 10000,
-            browserDisconnectTolerance: 3,
-            browserNoActivityTimeout: 60000,
-            flags: [
-                '--disable-web-security',
-                '--disable-gpu',
-                '--no-sandbox'
-            ],
-            // you can overwrite/extend the config further
+      esm: {
+        nodeResolve: true,
+      },
+      browserDisconnectTimeout: 10000,
+      browserDisconnectTolerance: 3,
+      browserNoActivityTimeout: 60000,
+      flags: ['--disable-web-security', '--disable-gpu', '--no-sandbox'],
+      // you can overwrite/extend the config further
 
-            // In headless mode (ie. CI), do not open a browser. The default will suffice
-            ...(headless ? {} : {browsers: ['Chrome']}),
-        }),
-    );
-    return config;
+      // In headless mode (ie. CI), do not open a browser. The default will suffice
+      ...(headless ? {} : { browsers: ['Chrome'] }),
+    }),
+  );
+  return config;
 };

--- a/resources/attic/app.js
+++ b/resources/attic/app.js
@@ -3,7 +3,7 @@ import './fx-model.js';
 import './fx-instance.js';
 import './fx-bind.js';
 
-//ui classes
+// ui classes
 import './ui/fx-control.js';
 import './ui/fx-group.js';
 import './ui/fx-button.js';
@@ -13,7 +13,7 @@ import './ui/fx-alert.js';
 import './ui/fx-hint.js';
 import './ui/fx-control.js';
 
-//action classes
+// action classes
 import './actions/fx-action.js';
 import './actions/fx-append.js';
 import './actions/fx-delete.js';
@@ -23,4 +23,3 @@ import './actions/fx-send.js';
 import './actions/fx-message.js';
 
 // import '@polymer/iron-ajax/iron-ajax';
-

--- a/resources/attic/fore-notification-styles.js
+++ b/resources/attic/fore-notification-styles.js
@@ -5,190 +5,193 @@ import '../assets/@vaadin/vaadin-lumo-styles/style.js';
 import '../assets/@vaadin/vaadin-lumo-styles/typography.js';
 import { html } from '../assets/@polymer/polymer/lib/utils/html-tag.js';
 
-const $_documentContainer = html`<dom-module id="fore-notification-card" theme-for="vaadin-notification-card">
-  <template>
-    <style>
-      :host {
-        position: relative;
-        margin: var(--lumo-space-s);
-      }
+const $_documentContainer = html`
+  <dom-module id="fore-notification-card" theme-for="vaadin-notification-card">
+    <template>
+      <style>
+        :host {
+          position: relative;
+          margin: var(--lumo-space-s);
+        }
 
-      [part="overlay"] {
-        background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
-        border-radius: var(--lumo-border-radius);
-        box-shadow: 0 0 0 1px var(--lumo-contrast-10pct), var(--lumo-box-shadow-l);
-        font-family: var(--lumo-font-family);
-        font-size: var(--lumo-font-size-m);
-        font-weight: 400;
-        line-height: var(--lumo-line-height-s);
-        letter-spacing: 0;
-        text-transform: none;
-        -webkit-text-size-adjust: 100%;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-      }
+        [part='overlay'] {
+          background: var(--lumo-base-color)
+            linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
+          border-radius: var(--lumo-border-radius);
+          box-shadow: 0 0 0 1px var(--lumo-contrast-10pct), var(--lumo-box-shadow-l);
+          font-family: var(--lumo-font-family);
+          font-size: var(--lumo-font-size-m);
+          font-weight: 400;
+          line-height: var(--lumo-line-height-s);
+          letter-spacing: 0;
+          text-transform: none;
+          -webkit-text-size-adjust: 100%;
+          -webkit-font-smoothing: antialiased;
+          -moz-osx-font-smoothing: grayscale;
+        }
 
-      [part="content"] {
-        padding: var(--lumo-space-wide-l);
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-      }
-
-      [part="content"] ::slotted(vaadin-button) {
-        flex: none;
-        margin: 0 calc(var(--lumo-space-s) * -1) 0 var(--lumo-space-m);
-      }
-
-      :host([slot^="middle"]) {
-        width: 20em;
-        max-width: 80vw;
-        margin: var(--lumo-space-s) auto;
-      }
-
-      :host([slot\$="stretch"]) {
-        margin: 0;
-      }
-
-      :host([slot\$="stretch"]) [part="overlay"] {
-        border-radius: 0;
-      }
-
-      @media (min-width: 421px) {
-        :host(:not([slot\$="stretch"])) {
+        [part='content'] {
+          padding: var(--lumo-space-wide-l);
           display: flex;
+          align-items: center;
+          justify-content: space-between;
         }
 
-        :host([slot\$="end"]) {
-          justify-content: flex-end;
+        [part='content'] ::slotted(vaadin-button) {
+          flex: none;
+          margin: 0 calc(var(--lumo-space-s) * -1) 0 var(--lumo-space-m);
         }
 
-        :host([slot^="middle"]),
-        :host([slot\$="center"]) {
-          display: flex;
-          justify-content: center;
+        :host([slot^='middle']) {
+          width: 20em;
+          max-width: 80vw;
+          margin: var(--lumo-space-s) auto;
         }
-      }
 
-      @keyframes lumo-notification-exit-fade-out {
-        100% {
-          opacity: 0;
+        :host([slot$='stretch']) {
+          margin: 0;
         }
-      }
 
-      @keyframes lumo-notification-enter-fade-in {
-        0% {
-          opacity: 0;
+        :host([slot$='stretch']) [part='overlay'] {
+          border-radius: 0;
         }
-      }
 
-      @keyframes lumo-notification-enter-slide-down {
-        0% {
-          transform: translateY(-200%);
-          opacity: 0;
+        @media (min-width: 421px) {
+          :host(:not([slot$='stretch'])) {
+            display: flex;
+          }
+
+          :host([slot$='end']) {
+            justify-content: flex-end;
+          }
+
+          :host([slot^='middle']),
+          :host([slot$='center']) {
+            display: flex;
+            justify-content: center;
+          }
         }
-      }
 
-      @keyframes lumo-notification-exit-slide-up {
-        100% {
-          transform: translateY(-200%);
-          opacity: 0;
+        @keyframes lumo-notification-exit-fade-out {
+          100% {
+            opacity: 0;
+          }
         }
-      }
 
-      @keyframes lumo-notification-enter-slide-up {
-        0% {
-          transform: translateY(200%);
-          opacity: 0;
+        @keyframes lumo-notification-enter-fade-in {
+          0% {
+            opacity: 0;
+          }
         }
-      }
 
-      @keyframes lumo-notification-exit-slide-down {
-        100% {
-          transform: translateY(200%);
-          opacity: 0;
+        @keyframes lumo-notification-enter-slide-down {
+          0% {
+            transform: translateY(-200%);
+            opacity: 0;
+          }
         }
-      }
 
-      :host([slot="middle"][opening]) {
-        animation: lumo-notification-enter-fade-in 300ms;
-      }
+        @keyframes lumo-notification-exit-slide-up {
+          100% {
+            transform: translateY(-200%);
+            opacity: 0;
+          }
+        }
 
-      :host([slot="middle"][closing]) {
-        animation: lumo-notification-exit-fade-out 300ms;
-      }
+        @keyframes lumo-notification-enter-slide-up {
+          0% {
+            transform: translateY(200%);
+            opacity: 0;
+          }
+        }
 
-      :host([slot^="top"][opening]) {
-        animation: lumo-notification-enter-slide-down 300ms;
-      }
+        @keyframes lumo-notification-exit-slide-down {
+          100% {
+            transform: translateY(200%);
+            opacity: 0;
+          }
+        }
 
-      :host([slot^="top"][closing]) {
-        animation: lumo-notification-exit-slide-up 300ms;
-      }
+        :host([slot='middle'][opening]) {
+          animation: lumo-notification-enter-fade-in 300ms;
+        }
 
-      :host([slot^="bottom"][opening]) {
-        animation: lumo-notification-enter-slide-up 300ms;
-      }
+        :host([slot='middle'][closing]) {
+          animation: lumo-notification-exit-fade-out 300ms;
+        }
 
-      :host([slot^="bottom"][closing]) {
-        animation: lumo-notification-exit-slide-down 300ms;
-      }
+        :host([slot^='top'][opening]) {
+          animation: lumo-notification-enter-slide-down 300ms;
+        }
 
-      :host([theme~="primary"]) [part="overlay"] {
-        background: var(--lumo-primary-color);
-        color: var(--lumo-primary-contrast-color);
-      }
+        :host([slot^='top'][closing]) {
+          animation: lumo-notification-exit-slide-up 300ms;
+        }
 
-      :host([theme~="primary"]) {
-        --_lumo-button-background-color: var(--lumo-shade-20pct);
-        --_lumo-button-color: var(--lumo-primary-contrast-color);
-        --_lumo-button-primary-background-color: var(--lumo-primary-contrast-color);
-        --_lumo-button-primary-color: var(--lumo-primary-text-color);
-      }
+        :host([slot^='bottom'][opening]) {
+          animation: lumo-notification-enter-slide-up 300ms;
+        }
 
-      :host([theme~="contrast"]) [part="overlay"] {
-        background: var(--lumo-contrast);
-        color: var(--lumo-base-color);
-      }
+        :host([slot^='bottom'][closing]) {
+          animation: lumo-notification-exit-slide-down 300ms;
+        }
 
-      :host([theme~="contrast"]) {
-        --_lumo-button-background-color: var(--lumo-contrast-20pct);
-        --_lumo-button-color: var(--lumo-base-color);
-        --_lumo-button-primary-background-color: var(--lumo-base-color);
-        --_lumo-button-primary-color: var(--lumo-contrast);
-      }
+        :host([theme~='primary']) [part='overlay'] {
+          background: var(--lumo-primary-color);
+          color: var(--lumo-primary-contrast-color);
+        }
 
-      :host([theme~="success"]) [part="overlay"] {
-        background: var(--lumo-success-color);
-        color: var(--lumo-success-contrast-color);
-      }
+        :host([theme~='primary']) {
+          --_lumo-button-background-color: var(--lumo-shade-20pct);
+          --_lumo-button-color: var(--lumo-primary-contrast-color);
+          --_lumo-button-primary-background-color: var(--lumo-primary-contrast-color);
+          --_lumo-button-primary-color: var(--lumo-primary-text-color);
+        }
 
-      :host([theme~="success"]) {
-        --_lumo-button-background-color: var(--lumo-shade-20pct);
-        --_lumo-button-color: var(--lumo-success-contrast-color);
-        --_lumo-button-primary-background-color: var(--lumo-success-contrast-color);
-        --_lumo-button-primary-color: var(--lumo-success-text-color);
-      }
+        :host([theme~='contrast']) [part='overlay'] {
+          background: var(--lumo-contrast);
+          color: var(--lumo-base-color);
+        }
 
-      :host([theme~="error"]) [part="overlay"] {
-        background: var(--lumo-error-color);
-        color: var(--lumo-error-contrast-color);
-      }
+        :host([theme~='contrast']) {
+          --_lumo-button-background-color: var(--lumo-contrast-20pct);
+          --_lumo-button-color: var(--lumo-base-color);
+          --_lumo-button-primary-background-color: var(--lumo-base-color);
+          --_lumo-button-primary-color: var(--lumo-contrast);
+        }
 
-      :host([theme~="modeless"]) {
-        --_lumo-button-background-color: orange;
-        --_lumo-button-color: var(--lumo-error-contrast-color);
-        --_lumo-button-primary-background-color: var(--lumo-error-contrast-color);
-        --_lumo-button-primary-color: var(--lumo-error-text-color);
-      }
-      :host([theme~="error"]) {
-        --_lumo-button-background-color: var(--lumo-shade-20pct);
-        --_lumo-button-color: var(--lumo-error-contrast-color);
-        --_lumo-button-primary-background-color: var(--lumo-error-contrast-color);
-        --_lumo-button-primary-color: var(--lumo-error-text-color);
-      }
-    </style>
-  </template>
-</dom-module>`;
+        :host([theme~='success']) [part='overlay'] {
+          background: var(--lumo-success-color);
+          color: var(--lumo-success-contrast-color);
+        }
+
+        :host([theme~='success']) {
+          --_lumo-button-background-color: var(--lumo-shade-20pct);
+          --_lumo-button-color: var(--lumo-success-contrast-color);
+          --_lumo-button-primary-background-color: var(--lumo-success-contrast-color);
+          --_lumo-button-primary-color: var(--lumo-success-text-color);
+        }
+
+        :host([theme~='error']) [part='overlay'] {
+          background: var(--lumo-error-color);
+          color: var(--lumo-error-contrast-color);
+        }
+
+        :host([theme~='modeless']) {
+          --_lumo-button-background-color: orange;
+          --_lumo-button-color: var(--lumo-error-contrast-color);
+          --_lumo-button-primary-background-color: var(--lumo-error-contrast-color);
+          --_lumo-button-primary-color: var(--lumo-error-text-color);
+        }
+        :host([theme~='error']) {
+          --_lumo-button-background-color: var(--lumo-shade-20pct);
+          --_lumo-button-color: var(--lumo-error-contrast-color);
+          --_lumo-button-primary-background-color: var(--lumo-error-contrast-color);
+          --_lumo-button-primary-color: var(--lumo-error-text-color);
+        }
+      </style>
+    </template>
+  </dom-module>
+`;
 
 document.head.appendChild($_documentContainer.content);

--- a/resources/attic/snippets.js
+++ b/resources/attic/snippets.js
@@ -1,15 +1,15 @@
 const slots = this.shadowRoot.querySelectorAll('slot');
 slots[0].addEventListener('slotchange', e => {
-    console.log('slotchange ', e);
-    console.log('slotchange ', slots[0].assignedElements());
-    const elements = slots[0].assignedElements();
-    elements.forEach(element => {
-        if(element.nodeName.toLocaleUpperCase() === 'fx-MODEL'){
-            // element._modelConstruct();
-            console.log('model ', element);
-            if(!element.inited){
-                element._modelConstruct();
-            }
-        }
-    });
+  console.log('slotchange ', e);
+  console.log('slotchange ', slots[0].assignedElements());
+  const elements = slots[0].assignedElements();
+  elements.forEach(element => {
+    if (element.nodeName.toLocaleUpperCase() === 'fx-MODEL') {
+      // element._modelConstruct();
+      console.log('model ', element);
+      if (!element.inited) {
+        element._modelConstruct();
+      }
+    }
+  });
 });

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,60 +1,61 @@
 import resolve from '@rollup/plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import {terser} from 'rollup-plugin-terser';
+import { terser } from 'rollup-plugin-terser';
 import minifyHTML from 'rollup-plugin-minify-html-literals';
 
 const { dependencies } = require('./package.json');
 
-export default [{
+export default [
+  {
     input: './index.js',
     output: [
-        {
-            file: 'dist/fore.js',
-            format: 'es',
-            sourcemap: true,
-        },
+      {
+        file: 'dist/fore.js',
+        format: 'es',
+        sourcemap: true,
+      },
     ],
-    external: (moduleName) => {
-        // All absolute imports should be regarded as external. Examples are 'fontoxpath',
-        // 'lit-element' or '@polymer/*'
-        return !/^(\.\/|\.\.\/)/.test(moduleName);
-    },
+    external: moduleName =>
+      // All absolute imports should be regarded as external. Examples are 'fontoxpath',
+      // 'lit-element' or '@polymer/*'
+      !/^(\.\/|\.\.\/)/.test(moduleName),
     plugins: [
-        resolve(),
-        babel({
-            babelrc: false,
-            exclude: 'node_modules/**',
-            plugins: [
-                // Tell babel to accept the `static READONLY_DEFAULT = false;` properties found in some places.
-                // TODO: reconsider whether that is a good idea.
-                [require('@babel/plugin-proposal-class-properties'), { loose: true }]
-            ],
-        }),
-        minifyHTML(),
-        terser(),
+      resolve(),
+      babel({
+        babelrc: false,
+        exclude: 'node_modules/**',
+        plugins: [
+          // Tell babel to accept the `static READONLY_DEFAULT = false;` properties found in some places.
+          // TODO: reconsider whether that is a good idea.
+          [require('@babel/plugin-proposal-class-properties'), { loose: true }],
+        ],
+      }),
+      minifyHTML(),
+      terser(),
     ],
-},
-{
+  },
+  {
     input: './index.js',
     output: [
-        {
-            file: 'dist/fore-all.js',
-            format: 'es',
-            sourcemap: true,
-        },
+      {
+        file: 'dist/fore-all.js',
+        format: 'es',
+        sourcemap: true,
+      },
     ],
     plugins: [
-        resolve(),
-        babel({
-            babelrc: false,
-            exclude: 'node_modules/**',
-            plugins: [
-                // Tell babel to accept the `static READONLY_DEFAULT = false;` properties found in some places.
-                // TODO: reconsider whether that is a good idea.
-                [require('@babel/plugin-proposal-class-properties'), { loose: true }]
-            ],
-        }),
-        minifyHTML(),
-        terser(),
+      resolve(),
+      babel({
+        babelrc: false,
+        exclude: 'node_modules/**',
+        plugins: [
+          // Tell babel to accept the `static READONLY_DEFAULT = false;` properties found in some places.
+          // TODO: reconsider whether that is a good idea.
+          [require('@babel/plugin-proposal-class-properties'), { loose: true }],
+        ],
+      }),
+      minifyHTML(),
+      terser(),
     ],
-}];
+  },
+];

--- a/src/ForeElementMixin.js
+++ b/src/ForeElementMixin.js
@@ -1,196 +1,196 @@
 import * as fx from 'fontoxpath';
-import {XPathUtil} from "./xpath-util.js";
-import {FxModel} from "./fx-model.js";
-import {Fore} from './fore.js';
+import { XPathUtil } from './xpath-util.js';
+import { FxModel } from './fx-model.js';
+import { Fore } from './fore.js';
 import { evaluateXPathToFirstNode } from './xpath-evaluation';
 
-
 // export class ForeElement extends LitElement {
-export const foreElementMixin = (superclass) => class ForeElementMixin extends superclass {
-
-
+export const foreElementMixin = superclass =>
+  class ForeElementMixin extends superclass {
     static get properties() {
-        return {
-            model: {
-                type: Object
-            },
-            ref:{
-                type:String
-            },
-            modelItem:{
-                type:Object
-            },
-            repeated:{
-                type:Boolean
-            }
-        };
+      return {
+        model: {
+          type: Object,
+        },
+        ref: {
+          type: String,
+        },
+        modelItem: {
+          type: Object,
+        },
+        repeated: {
+          type: Boolean,
+        },
+      };
     }
 
     constructor() {
-        super();
-        this.model = null;
-        this.modelItem = {};
-        this.ref = "";
-        this.repeated = false;
+      super();
+      this.model = null;
+      this.modelItem = {};
+      this.ref = '';
+      this.repeated = false;
     }
 
-    getModel(){
-        // console.log('getModel this ', this);
-        if(this.model){
-            return this.model;
-        }
-        // const ownerForm = this.closest('fx-form');
-        const ownerForm = this.getOwnerForm(this);
-        return ownerForm.querySelector('fx-model');
+    getModel() {
+      // console.log('getModel this ', this);
+      if (this.model) {
+        return this.model;
+      }
+      // const ownerForm = this.closest('fx-form');
+      const ownerForm = this.getOwnerForm(this);
+      return ownerForm.querySelector('fx-model');
     }
 
-    getOwnerForm(){
-        let currentElement = this;
-        while(currentElement && currentElement.parentNode) {
-            // console.log('current ', currentElement);
+    getOwnerForm() {
+      let currentElement = this;
+      while (currentElement && currentElement.parentNode) {
+        // console.log('current ', currentElement);
 
-            if(currentElement.nodeName .toUpperCase() === "FX-FORM"){
-                return currentElement;
-            }
-
-            if(currentElement.parentNode instanceof DocumentFragment) {
-                currentElement = currentElement.parentNode.host;
-            } else {
-                currentElement = currentElement.parentNode;
-            }
+        if (currentElement.nodeName.toUpperCase() === 'FX-FORM') {
+          return currentElement;
         }
-        return currentElement;
+
+        if (currentElement.parentNode instanceof DocumentFragment) {
+          currentElement = currentElement.parentNode.host;
+        } else {
+          currentElement = currentElement.parentNode;
+        }
+      }
+      return currentElement;
     }
 
     /**
      * evaluation of fx-bind and UiElements differ in details so that each class needs it's own implementation.
      */
-    evalInContext(){
-        // todo: should be replaced with Fore.getInScopeContext
-        const inscopeContext = this._inScopeContext();
+    evalInContext() {
+      // todo: should be replaced with Fore.getInScopeContext
+      const inscopeContext = this._inScopeContext();
 
-        if(this.ref===''){
+      if (this.ref === '') {
+        this.nodeset = inscopeContext;
+      } else if (Array.isArray(inscopeContext)) {
+        inscopeContext.forEach((n, index) => {
+          if (XPathUtil.isSelfReference(this.ref)) {
             this.nodeset = inscopeContext;
-        }else if(Array.isArray(inscopeContext)){
-
-            inscopeContext.forEach((n,index) => {
-                if(XPathUtil.isSelfReference(this.ref)){
-                    this.nodeset = inscopeContext;
-                }else{
-                    const localResult = evaluateXPathToFirstNode(this.ref, n, null, {namespaceResolver:  this.namespaceResolver});
-                    // console.log('local result: ', localResult);
-                    this.nodeset.push(localResult);
-                }
+          } else {
+            const localResult = evaluateXPathToFirstNode(this.ref, n, null, {
+              namespaceResolver: this.namespaceResolver,
             });
+            // console.log('local result: ', localResult);
+            this.nodeset.push(localResult);
+          }
+        });
+      } else {
+        // this.nodeset = fx.evaluateXPathToFirstNode(this.ref, inscopeContext, null, {namespaceResolver: this.namespaceResolver});
 
-        }else{
-            // this.nodeset = fx.evaluateXPathToFirstNode(this.ref, inscopeContext, null, {namespaceResolver: this.namespaceResolver});
-
-            // todo: code below fails - why?
-            const formElement = this.closest('fx-form');
-            this.nodeset = evaluateXPathToFirstNode(this.ref,inscopeContext,formElement,Fore.namespaceResolver)
-            // this.nodeset = Fore.evaluateXPath(this.ref,inscopeContext,formElement,Fore.namespaceResolver)
-        }
-        // console.log('UiElement evaluated to nodeset: ', this.nodeset);
+        // todo: code below fails - why?
+        const formElement = this.closest('fx-form');
+        this.nodeset = evaluateXPathToFirstNode(
+          this.ref,
+          inscopeContext,
+          formElement,
+          Fore.namespaceResolver,
+        );
+        // this.nodeset = Fore.evaluateXPath(this.ref,inscopeContext,formElement,Fore.namespaceResolver)
+      }
+      // console.log('UiElement evaluated to nodeset: ', this.nodeset);
     }
 
-
-    isNotBound(){
-        return !this.hasAttribute('ref');
+    isNotBound() {
+      return !this.hasAttribute('ref');
     }
 
-    isBound(){
-        return this.hasAttribute('ref');
+    isBound() {
+      return this.hasAttribute('ref');
     }
 
     getBindingExpr() {
-        if(this.hasAttribute('ref')){
-            return this.getAttribute('ref');
-        }
-        // try to get closest parent bind
-        const parent = this.parentNode.closest('[ref]');
-        if (!parent) {
-            return 'instance()'; // the default instance
-        }
-        return parent.getAttribute('ref');
+      if (this.hasAttribute('ref')) {
+        return this.getAttribute('ref');
+      }
+      // try to get closest parent bind
+      const parent = this.parentNode.closest('[ref]');
+      if (!parent) {
+        return 'instance()'; // the default instance
+      }
+      return parent.getAttribute('ref');
     }
 
-    _getParentBindingElement(start){
-        if(start.parentNode.host){
-            const {host} = start.parentNode;
-            if(host.hasAttribute('ref')){
-                return host;
-            }
-        }else if(start.parentNode){
-            if(start.parentNode.hasAttribute('ref')){
-                return this.parentNode;
-            }
-            this._getParentBindingElement(this.parentNode)
-
+    _getParentBindingElement(start) {
+      if (start.parentNode.host) {
+        const { host } = start.parentNode;
+        if (host.hasAttribute('ref')) {
+          return host;
         }
-        return null;
+      } else if (start.parentNode) {
+        if (start.parentNode.hasAttribute('ref')) {
+          return this.parentNode;
+        }
+        this._getParentBindingElement(this.parentNode);
+      }
+      return null;
     }
 
     getModelItem() {
-        // return this.model.bindingMap.find(m => m.refnode === this.nodeset);
-        // return this.getModel().bindingMap.find(m => m.refnode === this.nodeset);
+      // return this.model.bindingMap.find(m => m.refnode === this.nodeset);
+      // return this.getModel().bindingMap.find(m => m.refnode === this.nodeset);
 
-        const mi = this.getModel().getModelItem(this.nodeset);
-        if(mi){
-            this.modelItem = mi;
-        }
-/*
+      const mi = this.getModel().getModelItem(this.nodeset);
+      if (mi) {
+        this.modelItem = mi;
+      }
+      /*
         if(this.modelItem.node instanceof Node){
             // console.log('modelItem is already initialized ', this.modelItem);
             return this.modelItem;
         }
 */
 
-        const repeated = this.closest('fx-repeatitem');
-        let existed;
-        if(repeated){
-            const {index} = this.closest('fx-repeatitem');
-            if(Array.isArray(this.nodeset)){
-                existed = this.getModel().getModelItem(this.nodeset[index-1]);
-            }else {
-                existed = this.getModel().getModelItem(this.nodeset);
-            }
-        }else{
-            existed = this.getModel().getModelItem(this.nodeset);
+      const repeated = this.closest('fx-repeatitem');
+      let existed;
+      if (repeated) {
+        const { index } = this.closest('fx-repeatitem');
+        if (Array.isArray(this.nodeset)) {
+          existed = this.getModel().getModelItem(this.nodeset[index - 1]);
+        } else {
+          existed = this.getModel().getModelItem(this.nodeset);
         }
+      } else {
+        existed = this.getModel().getModelItem(this.nodeset);
+      }
 
-        if(!existed){
-            return FxModel.lazyCreateModelItem(this.getModel(), this.ref, this.nodeset);
-        }
-        return existed;
+      if (!existed) {
+        return FxModel.lazyCreateModelItem(this.getModel(), this.ref, this.nodeset);
+      }
+      return existed;
     }
 
+    _inScopeContext() {
+      let resultNodeset;
 
-    _inScopeContext(){
-        let resultNodeset;
+      // console.log('this ', this);
+      // console.log('this ', this.parentNode);
 
-        // console.log('this ', this);
-        // console.log('this ', this.parentNode);
-
-/*
+      /*
         if(this.nodeName.toUpperCase() === 'fx-REPEATITEM'){
             const index = this.index;
             console.log('>>>>>>>>>>< index ', index);
             return this.parentNode.host.nodeset[this.index -1];
         }
 */
-/*
+      /*
         if(this.repeated){
             const parentItem = this.parentNode.closest('fx-repeatitem');
             return parentItem.nodeset;
         }
 */
-        const repeatItem = this.parentNode.closest('fx-repeatitem');
-        if(repeatItem){
-            return repeatItem.nodeset;
-        }
+      const repeatItem = this.parentNode.closest('fx-repeatitem');
+      if (repeatItem) {
+        return repeatItem.nodeset;
+      }
 
-/*
+      /*
 
         let parentBind;
         if(this.parentNode.host){
@@ -202,23 +202,25 @@ export const foreElementMixin = (superclass) => class ForeElementMixin extends s
         // console.log('parentBind ', parentBind);
 */
 
-        const parentBind = this.parentNode.closest('[ref]');
+      const parentBind = this.parentNode.closest('[ref]');
 
-        if(parentBind !== null){
-            resultNodeset = parentBind.nodeset;
-        }else if(XPathUtil.isAbsolutePath(this.ref)){
-            const instanceId = XPathUtil.getInstanceId(this.ref);
-            resultNodeset = this.getModel().getInstance(instanceId).getDefaultContext();
-        }else if(this.getModel().getDefaultInstance() !== null){
-            resultNodeset = this.getModel().getDefaultInstance().getDefaultContext();
-        }else{
-            return [];
-        }
+      if (parentBind !== null) {
+        resultNodeset = parentBind.nodeset;
+      } else if (XPathUtil.isAbsolutePath(this.ref)) {
+        const instanceId = XPathUtil.getInstanceId(this.ref);
+        resultNodeset = this.getModel()
+          .getInstance(instanceId)
+          .getDefaultContext();
+      } else if (this.getModel().getDefaultInstance() !== null) {
+        resultNodeset = this.getModel()
+          .getDefaultInstance()
+          .getDefaultContext();
+      } else {
+        return [];
+      }
 
-        // console.log('_inScopeContext ', resultNodeset);
-        // todo: no support for xforms 'context' yet - see https://github.com/betterFORM/betterFORM/blob/02fd3ec595fa275589185658f3011a2e2e826f4d/core/src/main/java/de/betterform/xml/xforms/XFormsElement.java#L451
-        return resultNodeset;
+      // console.log('_inScopeContext ', resultNodeset);
+      // todo: no support for xforms 'context' yet - see https://github.com/betterFORM/betterFORM/blob/02fd3ec595fa275589185658f3011a2e2e826f4d/core/src/main/java/de/betterform/xml/xforms/XFormsElement.java#L451
+      return resultNodeset;
     }
-
-
-}
+  };

--- a/src/actions/StringTpl.js
+++ b/src/actions/StringTpl.js
@@ -5,17 +5,13 @@
  * credits go to https://stackoverflow.com/questions/29182244/convert-a-string-to-a-template-string (Daniel)
  */
 
-
 function parseTpl(template, map, fallback) {
-    return template.replace(/\$\{[^}]+\}/g, (match) =>
-        match
-        .slice(2, -1)
-        .trim()
-        .split(".")
-        .reduce(
-            (searchObject, key) => searchObject[key] || fallback || match,
-            map
-        )
-    );
+  return template.replace(/\$\{[^}]+\}/g, match =>
+    match
+      .slice(2, -1)
+      .trim()
+      .split('.')
+      .reduce((searchObject, key) => searchObject[key] || fallback || match, map),
+  );
 }
-export {parseTpl};
+export { parseTpl };

--- a/src/actions/fx-action.js
+++ b/src/actions/fx-action.js
@@ -1,4 +1,4 @@
-import { foreElementMixin } from "../ForeElementMixin.js";
+import { foreElementMixin } from '../ForeElementMixin.js';
 
 /**
  * `fx-action`
@@ -7,9 +7,8 @@ import { foreElementMixin } from "../ForeElementMixin.js";
  * @customElement
  * @demo demo/index.html
  */
-export class FxAction extends foreElementMixin(HTMLElement){
-
-/*
+export class FxAction extends foreElementMixin(HTMLElement) {
+  /*
     static get properties() {
         return {
             ...super.properties,
@@ -41,63 +40,64 @@ export class FxAction extends foreElementMixin(HTMLElement){
     }
 */
 
-    // eslint-disable-next-line no-useless-constructor
-    constructor(){
-        super();
+  // eslint-disable-next-line no-useless-constructor
+  constructor() {
+    super();
 
-        if(this.hasAttribute('event')){
-            this.event = this.getAttribute('event');
-        }else{
-            this.event = 'activate';
-        }
-
-        this.target = this.getAttribute('target');
-
-        if (this.target) {
-            this.targetElement = document.getElementById(this.target);
-            this.targetElement.addEventListener(this.event, e => this.execute(e));
-        } else {
-            this.targetElement = this.parentNode;
-            this.targetElement.addEventListener(this.event, e => this.execute(e));
-            // console.log('adding listener for ', this.event , ` to `, this);
-        }
-
-        this.needsRebuild = false;
-        this.needsRecalculate = false;
-        this.needsRevalidate = false;
-        this.needsRefresh = false;
+    if (this.hasAttribute('event')) {
+      this.event = this.getAttribute('event');
+    } else {
+      this.event = 'activate';
     }
 
-    connectedCallback(){
-        this.style.display = 'none';
+    this.target = this.getAttribute('target');
+
+    if (this.target) {
+      this.targetElement = document.getElementById(this.target);
+      this.targetElement.addEventListener(this.event, e => this.execute(e));
+    } else {
+      this.targetElement = this.parentNode;
+      this.targetElement.addEventListener(this.event, e => this.execute(e));
+      // console.log('adding listener for ', this.event , ` to `, this);
     }
 
-    execute (){
-        if(this.isBound()){
-            this.evalInContext();
-        }
-    }
+    this.needsRebuild = false;
+    this.needsRecalculate = false;
+    this.needsRevalidate = false;
+    this.needsRefresh = false;
+  }
 
-    actionPerformed(){
-        const model = this.getModel();
-        if(this.needsRebuild){
-            model.rebuild();
-        }
-        if(this.needsRecalculate){
-            model.recalculate();
-        }
-        if(this.needsRevalidate){
-            model.revalidate();
-        }
-        if(this.needsRefresh){
-            model.parentNode.refresh();
-        }
-    }
+  connectedCallback() {
+    this.style.display = 'none';
+  }
 
-
-    dispatchActionPerformed(){
-        this.dispatchEvent(new CustomEvent('action-performed', {composed: true, bubbles: true, detail: {}}));
+  execute() {
+    if (this.isBound()) {
+      this.evalInContext();
     }
+  }
+
+  actionPerformed() {
+    const model = this.getModel();
+    if (this.needsRebuild) {
+      model.rebuild();
+    }
+    if (this.needsRecalculate) {
+      model.recalculate();
+    }
+    if (this.needsRevalidate) {
+      model.revalidate();
+    }
+    if (this.needsRefresh) {
+      model.parentNode.refresh();
+    }
+  }
+
+  dispatchActionPerformed() {
+    this.dispatchEvent(
+      new CustomEvent('action-performed', { composed: true, bubbles: true, detail: {} }),
+    );
+  }
 }
 
 window.customElements.define('fx-action', FxAction);

--- a/src/actions/fx-append.js
+++ b/src/actions/fx-append.js
@@ -1,9 +1,9 @@
-import { FxAction } from "./fx-action.js";
+import * as fx from 'fontoxpath';
+import { FxAction } from './fx-action.js';
 // import '../fx-model.js';
 // import '../fx-instance.js';
-import * as fx from 'fontoxpath';
-import {FxInstance} from "../fx-instance";
-import {FxBind} from "../fx-bind";
+import { FxInstance } from '../fx-instance';
+import { FxBind } from '../fx-bind';
 
 /**
  * `fx-append`
@@ -15,177 +15,177 @@ import {FxBind} from "../fx-bind";
  * @customElement
  */
 class FxAppend extends FxAction {
-    static get properties() {
-        return {
-            ref: {
-                type: String
-            },
-            repeat:{
-                type: String
-            },
-            clear:{
-                type:String
-            }
-        };
-    }
-
-    constructor(){
-        super();
-        this.repeat = "";
-    }
-
-    connectedCallback(){
-        console.log('connectedCallback ', this);
-        this.ref = this.getAttribute('ref');
-        this.repeat = this.getAttribute('repeat');
-    }
-
-    /**
-     * appends a instance of the repeat template to the existing ones.
-     *
-     * The data structure to insert into the instance data is determined by the 'ref' attributes
-     * found in the template of the repeat. This is similar to lazy instance creation.
-     *
-     * Note: This is a significant difference to XForms which takes the instance nodes as template to insert but
-     * has the problem of empty nodesets not being able to insert an entry without using a separate instance
-     * holding the template.
-     *
-     * As a consequence the item that are appended are not propagated with values but empty. However usually
-     * that's what the user wants and not the other way round (duplicating the last data items). If the XForms
-     * behavior should be needed for some reason later on, it can be added easier by a providing an 'duplicate' action.
-     *
-     */
-    execute(){
-        const inscope = this._inScopeContext();
-        this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
-        const newItem = this._dataFromTemplate(inscope);
-        console.log('################ newItem ',newItem)
-
-        inscope.appendChild(newItem);
-
-        // newItem.textContent="new";
-
-        const instData = new XMLSerializer().serializeToString(this.getModel().getDefaultInstance().getInstanceData());
-        // console.log('modified instance ', this.getModel().getDefaultInstance().getInstanceData());
-        console.log('modified instance >>>');
-        console.log(instData);
-
-        this.needsRebuild=true;
-        this.needsRecalculate=true;
-        this.needsRevalidate=true;
-        this.needsRefresh=true;
-        this.actionPerformed();
-
-        const repeat = document.getElementById(this.repeat);
-        repeat.setIndex(this.nodeset.length+1);
-    }
-
-    _dataFromTemplate(inscope){
-        const parentForm = this.getOwnerForm(this);
-        const repeat = parentForm.querySelector(`#${this.repeat}`)
-        // console.log('_dataFromTemplate repeat', repeat);
-        // console.log('_dataFromTemplate repeat ref', repeat.ref);
-
-
-        const templ = repeat.shadowRoot.querySelector('template');
-        // console.log('_dataFromTemplate ', templ);
-        // console.log('_dataFromTemplate content', templ.content);
-
-        // iterate template for refs
-        // todo: will fail for pathes with predicates - need to be filtered before
-        // const rootNode = document.createElement(repeat.ref);
-
-
-
-        // const rootNode = document.createElement(repeat.ref);
-        const rootNode = inscope.ownerDocument.createElement(repeat.ref);
-
-
-
-        // const data = this._dataFromRefs(rootNode, templ.content)
-        const data = this._generateInstance(templ.content,rootNode);
-        // console.log('_dataFromTemplate DATA', data);
-        return data;
-    }
-
-    dispatch(){
-        const repeat = document.getElementById(this.repeat);
-        console.log('dispatching index change ', this.nodeset.length+1);
-        repeat.dispatchEvent(new CustomEvent('index-changed', {composed: true, bubbles: true, detail: {index:this.nodeset.length+1}}));
-    }
-
-    /**
-     * clear all text nodes and attribute values to get a 'clean' template.
-     * @param n
-     * @private
-     */
-    _clear(n){
-        let node = n.firstChild;
-        const attrs = n.attributes;
-        for (let i = 0; i < attrs.length; i++) {
-            // n.setAttribute(attrs[i].name,'');
-            attrs[i].value = '';
-        }
-        while (node) {
-            if(node.nodeType === 1 && node.hasAttributes()){
-                node.textContent = "";
-            }
-            this._clear(node);
-            node = node.nextSibling;
-        }
-
-    }
-
-    _generateInstance(start, parent){
-
-        if(start.nodeType === 1 && start.hasAttribute('ref')){
-            const ref = start.getAttribute('ref');
-
-            let generated;
-            if(ref === '.'){
-                // node.appendChild(document.createElement(repeatRef));
-            }else if(ref.startsWith('@')){
-                parent.setAttribute(ref.substring(1),'');
-            }else{
-                generated = document.createElement(ref);
-                parent.appendChild(generated);
-                if(start.children.length === 0){
-                    generated.textContent = start.textContent;
-                }
-            }
-        }
-
-        if(start.hasChildNodes()){
-            const list = start.children;
-            for(let i=0; i < list.length; i++){
-                this._generateInstance(list[i],parent)
-            }
-        }
-        return parent;
-    }
-
-
-    getInstanceId(){
-        if(this.ref.startsWith('instance(')){
-            return 'not implemented';
-        }else{
-            return 'default';
-        }
-    }
-
-    _fadeIn(el, display){
-        el.style.opacity = 0;
-        el.style.display = display || "block";
-
-        (function fade() {
-            var val = parseFloat(el.style.opacity);
-            if (!((val += .1) > 1)) {
-                el.style.opacity = val;
-                requestAnimationFrame(fade);
-            }
-        })();
+  static get properties() {
+    return {
+      ref: {
+        type: String,
+      },
+      repeat: {
+        type: String,
+      },
+      clear: {
+        type: String,
+      },
     };
+  }
 
+  constructor() {
+    super();
+    this.repeat = '';
+  }
+
+  connectedCallback() {
+    console.log('connectedCallback ', this);
+    this.ref = this.getAttribute('ref');
+    this.repeat = this.getAttribute('repeat');
+  }
+
+  /**
+   * appends a instance of the repeat template to the existing ones.
+   *
+   * The data structure to insert into the instance data is determined by the 'ref' attributes
+   * found in the template of the repeat. This is similar to lazy instance creation.
+   *
+   * Note: This is a significant difference to XForms which takes the instance nodes as template to insert but
+   * has the problem of empty nodesets not being able to insert an entry without using a separate instance
+   * holding the template.
+   *
+   * As a consequence the item that are appended are not propagated with values but empty. However usually
+   * that's what the user wants and not the other way round (duplicating the last data items). If the XForms
+   * behavior should be needed for some reason later on, it can be added easier by a providing an 'duplicate' action.
+   *
+   */
+  execute() {
+    const inscope = this._inScopeContext();
+    this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
+    const newItem = this._dataFromTemplate(inscope);
+    console.log('################ newItem ', newItem);
+
+    inscope.appendChild(newItem);
+
+    // newItem.textContent="new";
+
+    const instData = new XMLSerializer().serializeToString(
+      this.getModel()
+        .getDefaultInstance()
+        .getInstanceData(),
+    );
+    // console.log('modified instance ', this.getModel().getDefaultInstance().getInstanceData());
+    console.log('modified instance >>>');
+    console.log(instData);
+
+    this.needsRebuild = true;
+    this.needsRecalculate = true;
+    this.needsRevalidate = true;
+    this.needsRefresh = true;
+    this.actionPerformed();
+
+    const repeat = document.getElementById(this.repeat);
+    repeat.setIndex(this.nodeset.length + 1);
+  }
+
+  _dataFromTemplate(inscope) {
+    const parentForm = this.getOwnerForm(this);
+    const repeat = parentForm.querySelector(`#${this.repeat}`);
+    // console.log('_dataFromTemplate repeat', repeat);
+    // console.log('_dataFromTemplate repeat ref', repeat.ref);
+
+    const templ = repeat.shadowRoot.querySelector('template');
+    // console.log('_dataFromTemplate ', templ);
+    // console.log('_dataFromTemplate content', templ.content);
+
+    // iterate template for refs
+    // todo: will fail for pathes with predicates - need to be filtered before
+    // const rootNode = document.createElement(repeat.ref);
+
+    // const rootNode = document.createElement(repeat.ref);
+    const rootNode = inscope.ownerDocument.createElement(repeat.ref);
+
+    // const data = this._dataFromRefs(rootNode, templ.content)
+    const data = this._generateInstance(templ.content, rootNode);
+    // console.log('_dataFromTemplate DATA', data);
+    return data;
+  }
+
+  dispatch() {
+    const repeat = document.getElementById(this.repeat);
+    console.log('dispatching index change ', this.nodeset.length + 1);
+    repeat.dispatchEvent(
+      new CustomEvent('index-changed', {
+        composed: true,
+        bubbles: true,
+        detail: { index: this.nodeset.length + 1 },
+      }),
+    );
+  }
+
+  /**
+   * clear all text nodes and attribute values to get a 'clean' template.
+   * @param n
+   * @private
+   */
+  _clear(n) {
+    let node = n.firstChild;
+    const attrs = n.attributes;
+    for (let i = 0; i < attrs.length; i++) {
+      // n.setAttribute(attrs[i].name,'');
+      attrs[i].value = '';
+    }
+    while (node) {
+      if (node.nodeType === 1 && node.hasAttributes()) {
+        node.textContent = '';
+      }
+      this._clear(node);
+      node = node.nextSibling;
+    }
+  }
+
+  _generateInstance(start, parent) {
+    if (start.nodeType === 1 && start.hasAttribute('ref')) {
+      const ref = start.getAttribute('ref');
+
+      let generated;
+      if (ref === '.') {
+        // node.appendChild(document.createElement(repeatRef));
+      } else if (ref.startsWith('@')) {
+        parent.setAttribute(ref.substring(1), '');
+      } else {
+        generated = document.createElement(ref);
+        parent.appendChild(generated);
+        if (start.children.length === 0) {
+          generated.textContent = start.textContent;
+        }
+      }
+    }
+
+    if (start.hasChildNodes()) {
+      const list = start.children;
+      for (let i = 0; i < list.length; i++) {
+        this._generateInstance(list[i], parent);
+      }
+    }
+    return parent;
+  }
+
+  getInstanceId() {
+    if (this.ref.startsWith('instance(')) {
+      return 'not implemented';
+    }
+    return 'default';
+  }
+
+  _fadeIn(el, display) {
+    el.style.opacity = 0;
+    el.style.display = display || 'block';
+
+    (function fade() {
+      let val = parseFloat(el.style.opacity);
+      if (!((val += 0.1) > 1)) {
+        el.style.opacity = val;
+        requestAnimationFrame(fade);
+      }
+    })();
+  }
 }
 
 window.customElements.define('fx-append', FxAppend);

--- a/src/actions/fx-delete.js
+++ b/src/actions/fx-delete.js
@@ -1,6 +1,6 @@
-import {FxAction} from "./fx-action.js";
+import { FxAction } from './fx-action.js';
 // import * as fx from "fontoxpath";
-import {Fore} from "../fore.js";
+import { Fore } from '../fore.js';
 
 /**
  * `fx-delete`
@@ -10,8 +10,7 @@ import {Fore} from "../fore.js";
  * @demo demo/todo.html
  */
 class FxDelete extends FxAction {
-
-    /*
+  /*
         static get properties() {
             return {
                 ...super.properties,
@@ -22,69 +21,65 @@ class FxDelete extends FxAction {
         }
     */
 
-    constructor() {
-        super();
-        this.repeatId = '';
+  constructor() {
+    super();
+    this.repeatId = '';
+  }
+
+  /**
+   * deletes a
+   */
+  execute() {
+    super.execute();
+    console.log('##### fx-delete executing...');
+
+    // this.ref = this.getAttribute('ref');
+    // const inscope = this._inScopeContext();
+    // this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
+
+    console.log('delete nodeset ', this.nodeset);
+
+    // ### if there's no repeat the delete action is inside of a repeat template
+    if (this.repeatId === '') {
+      // find the index to delete
+      const rItem = this.parentNode.closest('fx-repeatitem');
+      const idx = Array.from(rItem.parentNode.children).indexOf(rItem) + 1;
+      // console.log('>>> idx to delete ', idx);
+
+      // ### get the model now as it'll be hard once we've deleted ourselves ;)
+      this.model = this.getModel();
+      const repeat = this.parentNode.closest('fx-repeat');
+
+      // ### update the nodeset
+      let nodeToDelete;
+      if (Array.isArray(this.nodeset)) {
+        nodeToDelete = this.nodeset[idx - 1];
+      } else {
+        nodeToDelete = this.nodeset;
+      }
+      const p = nodeToDelete.parentNode;
+      p.removeChild(nodeToDelete);
+
+      // ### remove the repeatitem
+      rItem.parentNode.removeChild(rItem);
+
+      // ### update the index (set 'repeat-index' attribute on repeatitem
+      const { repeatSize } = repeat;
+      if (idx === 1 || repeatSize === 1) {
+        repeat.setIndex(1);
+      } else if (idx > repeatSize) {
+        repeat.setIndex(repeatSize);
+      } else {
+        repeat.setIndex(idx);
+      }
     }
 
-
-    /**
-     * deletes a
-     */
-    execute() {
-        super.execute();
-        console.log('##### fx-delete executing...');
-
-        // this.ref = this.getAttribute('ref');
-        // const inscope = this._inScopeContext();
-        // this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
-
-
-        console.log('delete nodeset ', this.nodeset);
-
-        // ### if there's no repeat the delete action is inside of a repeat template
-        if (this.repeatId === '') {
-
-            // find the index to delete
-            const rItem = this.parentNode.closest('fx-repeatitem');
-            const idx = Array.from(rItem.parentNode.children).indexOf(rItem) + 1;
-            // console.log('>>> idx to delete ', idx);
-
-            // ### get the model now as it'll be hard once we've deleted ourselves ;)
-            this.model = this.getModel();
-            const repeat = this.parentNode.closest('fx-repeat');
-
-            // ### update the nodeset
-            let nodeToDelete;
-            if (Array.isArray(this.nodeset)) {
-                nodeToDelete = this.nodeset[idx - 1];
-            } else {
-                nodeToDelete = this.nodeset;
-            }
-            const p = nodeToDelete.parentNode;
-            p.removeChild(nodeToDelete);
-
-            // ### remove the repeatitem
-            rItem.parentNode.removeChild(rItem);
-
-            // ### update the index (set 'repeat-index' attribute on repeatitem
-            const {repeatSize} = repeat;
-            if (idx === 1 || repeatSize === 1) {
-                repeat.setIndex(1);
-            } else if (idx > repeatSize) {
-                repeat.setIndex(repeatSize);
-            } else {
-                repeat.setIndex(idx);
-            }
-        }
-
-        this.needsRebuild = true;
-        this.needsRecalculate = true;
-        this.needsRevalidate = true;
-        this.needsRefresh = true;
-        this.actionPerformed();
-    }
-
+    this.needsRebuild = true;
+    this.needsRecalculate = true;
+    this.needsRevalidate = true;
+    this.needsRefresh = true;
+    this.actionPerformed();
+  }
 }
 
 window.customElements.define('fx-delete', FxDelete);

--- a/src/actions/fx-message.js
+++ b/src/actions/fx-message.js
@@ -1,5 +1,5 @@
-import {LitElement, html, css} from 'lit-element';
-import {parseTpl} from './StringTpl.js';
+import { LitElement, html, css } from 'lit-element';
+import { parseTpl } from './StringTpl.js';
 
 /**
  * `fx-message`
@@ -11,82 +11,82 @@ import {parseTpl} from './StringTpl.js';
  * @polymer
  */
 class FxMessage extends LitElement {
-
-    static get template() {
-        return html`
-          <style>
-            :host {
-              display: none;
-            }
-          </style>
-        `;
-    }
-
-    static get properties() {
-        return {
-            bind: {
-                type: String
-            },
-            repeat: {
-                type: String
-            },
-            event: {
-                type: String
-            },
-            level: {
-                type: String,
-                value: 'ephemeral'
-            },
-            id: {
-                type: String
-            },
-            eventTarget: {
-                type: String
-            },
-            targetElement:{
-                type: Object
-            }
-        };
-    }
-
-    connectedCallback() {
-        super.connectedCallback();
-        console.log('### fx-message connected ', this);
-
-        if (this.eventTarget) {
-            this.targetElement = document.getElementById(this.eventTarget);
-            this.targetElement.addEventListener(this.event, e => this.execute(e));
-        } else {
-            this.targetElement = this.parentNode;
-            this.targetElement.addEventListener(this.event, e => this.execute(e));
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: none;
         }
-        // this.id = "foobar";
+      </style>
+    `;
+  }
+
+  static get properties() {
+    return {
+      bind: {
+        type: String,
+      },
+      repeat: {
+        type: String,
+      },
+      event: {
+        type: String,
+      },
+      level: {
+        type: String,
+        value: 'ephemeral',
+      },
+      id: {
+        type: String,
+      },
+      eventTarget: {
+        type: String,
+      },
+      targetElement: {
+        type: Object,
+      },
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    console.log('### fx-message connected ', this);
+
+    if (this.eventTarget) {
+      this.targetElement = document.getElementById(this.eventTarget);
+      this.targetElement.addEventListener(this.event, e => this.execute(e));
+    } else {
+      this.targetElement = this.parentNode;
+      this.targetElement.addEventListener(this.event, e => this.execute(e));
     }
+    // this.id = "foobar";
+  }
 
-    disconnectedCallback() {
-        super.disconnectedCallback();
-        this.targetElement.removeEventListener(this.event, e => this.execute(e));
-    }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.targetElement.removeEventListener(this.event, e => this.execute(e));
+  }
 
-    execute(e) {
-        console.log('fx-message.execute ', e.detail);
-        console.log('fx-message.execute textContent: ', this.textContent);
+  execute(e) {
+    console.log('fx-message.execute ', e.detail);
+    console.log('fx-message.execute textContent: ', this.textContent);
 
-        const details = e.detail;
-        let tmpl = this.textContent;
+    const details = e.detail;
+    const tmpl = this.textContent;
 
-        const result = parseTpl(this.textContent, details);
-        console.log('result: ', result);
+    const result = parseTpl(this.textContent, details);
+    console.log('result: ', result);
 
-        // this.closest('fx-form').message(e.detail, result, this.level);
+    // this.closest('fx-form').message(e.detail, result, this.level);
 
-        this.dispatchEvent(new CustomEvent('message', {
-            composed: true, bubbles: true,
-            detail: {'level': this.level, 'message': result}
-        }));
-
-    }
-
+    this.dispatchEvent(
+      new CustomEvent('message', {
+        composed: true,
+        bubbles: true,
+        detail: { level: this.level, message: result },
+      }),
+    );
+  }
 }
 
 window.customElements.define('fx-message', FxMessage);

--- a/src/actions/fx-send.js
+++ b/src/actions/fx-send.js
@@ -1,7 +1,7 @@
-import {FxAction} from './fx-action.js';
+import { FxAction } from './fx-action.js';
 
-import "../fx-model.js";
-import "../fx-submission.js";
+import '../fx-model.js';
+import '../fx-submission.js';
 
 /**
  * `fx-send` - finds and activates a `fx-submission` element.
@@ -10,52 +10,47 @@ import "../fx-submission.js";
  * @customElement
  */
 export default class FxSend extends FxAction {
+  static get properties() {
+    return {
+      ...super.properties,
+      submission: {
+        type: String,
+      },
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties,
-            submission: {
-                type: String
-            }
-        };
+  constructor() {
+    super();
+    this.value = '';
+  }
+
+  connectedCallback() {
+    console.log('connectedCallback ', this);
+    this.submission = this.getAttribute('submission');
+  }
+
+  execute() {
+    super.execute();
+
+    console.log('submitting ', this.submission);
+    console.log('submitting model', this.getModel());
+
+    // if not exists signal error
+    const submission = this.getModel().querySelector(`#${this.submission}`);
+    if (submission === null) {
+      this.dispatchEvent(
+        new CustomEvent('error', {
+          composed: true,
+          bubbles: true,
+          detail: { message: `fx-submission element with id: '${this.submission}' not found` },
+        }),
+      );
     }
+    console.log('submission', submission);
+    submission.submit();
 
-    constructor(){
-        super();
-        this.value = "";
-    }
-
-    connectedCallback(){
-        console.log('connectedCallback ', this);
-        this.submission = this.getAttribute('submission');
-    }
-
-    execute() {
-        super.execute();
-
-        console.log('submitting ', this.submission);
-        console.log('submitting model', this.getModel());
-
-        //if not exists signal error
-        const submission = this.getModel().querySelector(`#${this.submission}`);
-        if(submission === null){
-            this.dispatchEvent(new CustomEvent('error', {
-                composed: true,
-                bubbles: true,
-                detail: {message: `fx-submission element with id: '${  this.submission  }' not found`}
-            }));
-
-        }
-        console.log('submission', submission);
-        submission.submit();
-
-
-        //if not of type fx-submission signal error
-
-
-    }
-
-
+    // if not of type fx-submission signal error
+  }
 }
 
 window.customElements.define('fx-send', FxSend);

--- a/src/actions/fx-setvalue.js
+++ b/src/actions/fx-setvalue.js
@@ -1,6 +1,6 @@
-import {FxAction} from './fx-action.js';
+import { FxAction } from './fx-action.js';
 
-import "../fx-model.js";
+import '../fx-model.js';
 
 /**
  * `fx-setvalue`
@@ -8,51 +8,49 @@ import "../fx-model.js";
  * @customElement
  */
 export default class FxSetvalue extends FxAction {
+  static get properties() {
+    return {
+      ...super.properties,
+      ref: {
+        type: String,
+      },
+      value: {
+        type: String,
+      },
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties,
-            ref:{
-                type: String
-            },
-            value: {
-                type: String
-            }
-        };
+  constructor() {
+    super();
+    this.ref = '';
+    this.value = '';
+  }
+
+  connectedCallback() {
+    // console.log('connectedCallback ', this);
+    if (this.hasAttribute('ref')) {
+      this.ref = this.getAttribute('ref');
+    } else {
+      throw new Error('fx-setvalue must specify a "ref" attribute');
     }
+    this.value = this.getAttribute('value');
+  }
 
-    constructor(){
-        super();
-        this.ref="";
-        this.value = "";
+  execute() {
+    super.execute();
+    // this.setValue(this.modelItem, this.value);
+
+    let { value } = this;
+    if (this.value !== null) {
+      value = this.value;
+    } else if (this.textContent !== '') {
+      value = this.textContent;
+    } else {
+      value = '';
     }
+    this.setValue(this.getModelItem(), value);
 
-    connectedCallback(){
-        // console.log('connectedCallback ', this);
-        if(this.hasAttribute('ref')){
-            this.ref = this.getAttribute('ref');
-        }else{
-            throw new Error('fx-setvalue must specify a "ref" attribute');
-        }
-        this.value = this.getAttribute('value');
-    }
-
-    execute() {
-        super.execute();
-        // this.setValue(this.modelItem, this.value);
-
-        let value = this.value;
-        if(this.value !== null){
-            value = this.value;
-        }else if(this.textContent !== "") {
-            value = this.textContent;
-        }else{
-            value = "";
-        }
-        this.setValue(this.getModelItem(), value);
-
-
-        /*
+    /*
                 const repeated = this.closest('fx-repeat-item');
 
                 const path = this.ownerForm.resolveBinding(this);
@@ -79,28 +77,27 @@ export default class FxSetvalue extends FxAction {
                 }
         */
 
-        // super.execute();
+    // super.execute();
+  }
+
+  setValue(modelItem, newVal) {
+    console.log('setvalue[1]  ', modelItem, newVal);
+
+    if (!modelItem) return;
+
+    if (modelItem.value !== newVal) {
+      modelItem.value = newVal;
+      modelItem.changed = true;
+
+      this.needsRebuild = false;
+      this.needsRecalculate = true;
+      this.needsRevalidate = true;
+      this.needsRefresh = true;
+      console.log('setvalue[2] ', modelItem, newVal);
+      this.actionPerformed();
     }
-
-    setValue(modelItem, newVal){
-        console.log('setvalue[1]  ', modelItem, newVal);
-
-        if(!modelItem) return;
-
-        if(modelItem.value !== newVal){
-            modelItem.value = newVal;
-            modelItem.changed = true;
-
-            this.needsRebuild = false;
-            this.needsRecalculate = true;
-            this.needsRevalidate = true;
-            this.needsRefresh = true;
-            console.log('setvalue[2] ', modelItem, newVal);
-            this.actionPerformed();
-        }
-        // this.setAttribute('value', modelItem.value);
-    }
-
+    // this.setAttribute('value', modelItem.value);
+  }
 }
 
 window.customElements.define('fx-setvalue', FxSetvalue);

--- a/src/actions/fx-toggle.js
+++ b/src/actions/fx-toggle.js
@@ -1,33 +1,31 @@
-import {FxAction} from './fx-action.js';
+import { FxAction } from './fx-action.js';
 
 /**
  * `fx-toggle`
  *
  */
 class FxToggle extends FxAction {
-
-    connectedCallback() {
-        if(this.hasAttribute('case')){
-            this.case = this.getAttribute('case');
-        }
+  connectedCallback() {
+    if (this.hasAttribute('case')) {
+      this.case = this.getAttribute('case');
     }
+  }
 
-/*
+  /*
     disconnectedCallback() {
         super.disconnectedCallback();
     }
 
 */
-    execute() {
-        console.log('### fx-toggle.execute ');
-        if(this.case){
-            const ownerForm = this.getOwnerForm();
-            const caseElement = ownerForm.querySelector(`#${this.case}`);
-            const fxSwitch = caseElement.parentNode;
-            fxSwitch.toggle(caseElement)
-        }
+  execute() {
+    console.log('### fx-toggle.execute ');
+    if (this.case) {
+      const ownerForm = this.getOwnerForm();
+      const caseElement = ownerForm.querySelector(`#${this.case}`);
+      const fxSwitch = caseElement.parentNode;
+      fxSwitch.toggle(caseElement);
     }
-
+  }
 }
 
 window.customElements.define('fx-toggle', FxToggle);

--- a/src/dep_graph.js
+++ b/src/dep_graph.js
@@ -25,14 +25,14 @@ function createDFS(edges, leavesOnly, result, circular) {
     if (visited[start]) {
       return;
     }
-    var inCurrentPath = {};
-    var currentPath = [];
-    var todo = []; // used as a stack
+    const inCurrentPath = {};
+    const currentPath = [];
+    const todo = []; // used as a stack
     todo.push({ node: start, processed: false });
     while (todo.length > 0) {
-      var current = todo[todo.length - 1]; // peek at the todo stack
-      var processed = current.processed;
-      var node = current.node;
+      const current = todo[todo.length - 1]; // peek at the todo stack
+      const { processed } = current;
+      const { node } = current;
       if (!processed) {
         // Haven't visited edges yet (visiting phase)
         if (visited[node]) {
@@ -46,11 +46,13 @@ function createDFS(edges, leavesOnly, result, circular) {
             continue;
           }
           currentPath.push(node);
-          window.dispatchEvent(new CustomEvent('compute-exception', {
-            composed: true,
-            bubbles: true,
-            detail: {"path": currentPath}
-          }));
+          window.dispatchEvent(
+            new CustomEvent('compute-exception', {
+              composed: true,
+              bubbles: true,
+              detail: { path: currentPath },
+            }),
+          );
           return;
           // alert('‘circular path: ' + currentPath);
           // throw new DepGraphCycleError(currentPath);
@@ -58,9 +60,9 @@ function createDFS(edges, leavesOnly, result, circular) {
 
         inCurrentPath[node] = true;
         currentPath.push(node);
-        var nodeEdges = edges[node];
+        const nodeEdges = edges[node];
         // (push edges onto the todo stack in reverse order to be order-compatible with the old DFS implementation)
-        for (var i = nodeEdges.length - 1; i >= 0; i--) {
+        for (let i = nodeEdges.length - 1; i >= 0; i--) {
           todo.push({ node: nodeEdges[i], processed: false });
         }
         current.processed = true;
@@ -94,19 +96,19 @@ export default function DepGraph(opts) {
   this.outgoingEdges = {}; // Node -> [Dependency Node]
   this.incomingEdges = {}; // Node -> [Dependant Node]
   this.circular = opts && !!opts.circular; // Allows circular deps
-};
+}
 
 DepGraph.prototype = {
   /**
    * The number of nodes in the graph.
    */
-  size: function() {
+  size() {
     return Object.keys(this.nodes).length;
   },
   /**
    * Add a node to the dependency graph. If a node already exists, this method will do nothing.
    */
-  addNode: function(node, data) {
+  addNode(node, data) {
     if (!this.hasNode(node)) {
       // Checking the arguments length allows the user to add a node with undefined data
       if (arguments.length === 2) {
@@ -121,14 +123,14 @@ DepGraph.prototype = {
   /**
    * Remove a node from the dependency graph. If a node does not exist, this method will do nothing.
    */
-  removeNode: function(node) {
+  removeNode(node) {
     if (this.hasNode(node)) {
       delete this.nodes[node];
       delete this.outgoingEdges[node];
       delete this.incomingEdges[node];
       [this.incomingEdges, this.outgoingEdges].forEach(function(edgeList) {
-        Object.keys(edgeList).forEach(function(key) {
-          var idx = edgeList[key].indexOf(node);
+        Object.keys(edgeList).forEach(key => {
+          const idx = edgeList[key].indexOf(node);
           if (idx >= 0) {
             edgeList[key].splice(idx, 1);
           }
@@ -139,40 +141,39 @@ DepGraph.prototype = {
   /**
    * Check if a node exists in the graph
    */
-  hasNode: function(node) {
+  hasNode(node) {
     return this.nodes.hasOwnProperty(node);
     // return this.nodes.indexOf(node);
   },
   /**
    * Get the data associated with a node name
    */
-  getNodeData: function(node) {
+  getNodeData(node) {
     if (this.hasNode(node)) {
       return this.nodes[node];
-    } else {
-      throw new Error("Node does not exist: " + node);
     }
+    throw new Error(`Node does not exist: ${node}`);
   },
   /**
    * Set the associated data for a given node name. If the node does not exist, this method will throw an error
    */
-  setNodeData: function(node, data) {
+  setNodeData(node, data) {
     if (this.hasNode(node)) {
       this.nodes[node] = data;
     } else {
-      throw new Error("Node does not exist: " + node);
+      throw new Error(`Node does not exist: ${node}`);
     }
   },
   /**
    * Add a dependency between two nodes. If either of the nodes does not exist,
    * an Error will be thrown.
    */
-  addDependency: function(from, to) {
+  addDependency(from, to) {
     if (!this.hasNode(from)) {
-      throw new Error("Node does not exist: " + from);
+      throw new Error(`Node does not exist: ${from}`);
     }
     if (!this.hasNode(to)) {
-      throw new Error("Node does not exist: " + to);
+      throw new Error(`Node does not exist: ${to}`);
     }
     if (this.outgoingEdges[from].indexOf(to) === -1) {
       this.outgoingEdges[from].push(to);
@@ -185,8 +186,8 @@ DepGraph.prototype = {
   /**
    * Remove a dependency between two nodes.
    */
-  removeDependency: function(from, to) {
-    var idx;
+  removeDependency(from, to) {
+    let idx;
     if (this.hasNode(from)) {
       idx = this.outgoingEdges[from].indexOf(to);
       if (idx >= 0) {
@@ -205,11 +206,11 @@ DepGraph.prototype = {
    * Return a clone of the dependency graph. If any custom data is attached
    * to the nodes, it will only be shallow copied.
    */
-  clone: function() {
-    var source = this;
-    var result = new DepGraph();
-    var keys = Object.keys(source.nodes);
-    keys.forEach(function(n) {
+  clone() {
+    const source = this;
+    const result = new DepGraph();
+    const keys = Object.keys(source.nodes);
+    keys.forEach(n => {
       result.nodes[n] = source.nodes[n];
       result.outgoingEdges[n] = source.outgoingEdges[n].slice(0);
       result.incomingEdges[n] = source.incomingEdges[n].slice(0);
@@ -225,24 +226,18 @@ DepGraph.prototype = {
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned
    * in the array.
    */
-  dependenciesOf: function(node, leavesOnly) {
+  dependenciesOf(node, leavesOnly) {
     if (this.hasNode(node)) {
-      var result = [];
-      var DFS = createDFS(
-        this.outgoingEdges,
-        leavesOnly,
-        result,
-        this.circular
-      );
+      const result = [];
+      const DFS = createDFS(this.outgoingEdges, leavesOnly, result, this.circular);
       DFS(node);
-      var idx = result.indexOf(node);
+      const idx = result.indexOf(node);
       if (idx >= 0) {
         result.splice(idx, 1);
       }
       return result;
-    } else {
-      throw new Error("Node does not exist: " + node);
     }
+    throw new Error(`Node does not exist: ${node}`);
   },
   /**
    * get an array containing the nodes that depend on the specified node (transitively).
@@ -251,24 +246,18 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
    */
-  dependantsOf: function(node, leavesOnly) {
+  dependantsOf(node, leavesOnly) {
     if (this.hasNode(node)) {
-      var result = [];
-      var DFS = createDFS(
-        this.incomingEdges,
-        leavesOnly,
-        result,
-        this.circular
-      );
+      const result = [];
+      const DFS = createDFS(this.incomingEdges, leavesOnly, result, this.circular);
       DFS(node);
-      var idx = result.indexOf(node);
+      const idx = result.indexOf(node);
       if (idx >= 0) {
         result.splice(idx, 1);
       }
       return result;
-    } else {
-      throw new Error("Node does not exist: " + node);
     }
+    throw new Error(`Node does not exist: ${node}`);
   },
   /**
    * Construct the overall processing order for the dependency graph.
@@ -277,52 +266,42 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
    */
-  overallOrder: function(leavesOnly) {
-    var self = this;
-    var result = [];
-    var keys = Object.keys(this.nodes);
+  overallOrder(leavesOnly) {
+    const self = this;
+    const result = [];
+    const keys = Object.keys(this.nodes);
     if (keys.length === 0) {
       return result; // Empty graph
-    } else {
-      if (!this.circular) {
-        // Look for cycles - we run the DFS starting at all the nodes in case there
-        // are several disconnected subgraphs inside this dependency graph.
-        var CycleDFS = createDFS(this.outgoingEdges, false, [], this.circular);
-        keys.forEach(function(n) {
-          CycleDFS(n);
-        });
-      }
+    }
+    if (!this.circular) {
+      // Look for cycles - we run the DFS starting at all the nodes in case there
+      // are several disconnected subgraphs inside this dependency graph.
+      const CycleDFS = createDFS(this.outgoingEdges, false, [], this.circular);
+      keys.forEach(n => {
+        CycleDFS(n);
+      });
+    }
 
-      var DFS = createDFS(
-        this.outgoingEdges,
-        leavesOnly,
-        result,
-        this.circular
-      );
-      // Find all potential starting points (nodes with nothing depending on them) an
-      // run a DFS starting at these points to get the order
+    const DFS = createDFS(this.outgoingEdges, leavesOnly, result, this.circular);
+    // Find all potential starting points (nodes with nothing depending on them) an
+    // run a DFS starting at these points to get the order
+    keys
+      .filter(node => self.incomingEdges[node].length === 0)
+      .forEach(n => {
+        DFS(n);
+      });
+
+    // If we're allowing cycles - we need to run the DFS against any remaining
+    // nodes that did not end up in the initial result (as they are part of a
+    // subgraph that does not have a clear starting point)
+    if (this.circular) {
       keys
-        .filter(function(node) {
-          return self.incomingEdges[node].length === 0;
-        })
-        .forEach(function(n) {
+        .filter(node => result.indexOf(node) === -1)
+        .forEach(n => {
           DFS(n);
         });
-
-      // If we're allowing cycles - we need to run the DFS against any remaining
-      // nodes that did not end up in the initial result (as they are part of a
-      // subgraph that does not have a clear starting point)
-      if (this.circular) {
-        keys
-          .filter(function(node) {
-            return result.indexOf(node) === -1;
-          })
-          .forEach(function(n) {
-            DFS(n);
-          });
-      }
-
-      return result;
     }
-  }
+
+    return result;
+  },
 };

--- a/src/fore.js
+++ b/src/fore.js
@@ -1,153 +1,142 @@
-import * as fx from "fontoxpath";
-import {XPathUtil} from "./xpath-util";
+import * as fx from 'fontoxpath';
+import { XPathUtil } from './xpath-util';
 
-export class Fore{
+export class Fore {
+  static READONLY_DEFAULT = false;
 
-    static READONLY_DEFAULT = false;
+  static REQUIRED_DEFAULT = false;
 
-    static REQUIRED_DEFAULT = false;
+  static RELEVANT_DEFAULT = true;
 
-    static RELEVANT_DEFAULT = true;
+  static CONSTRAINT_DEFAULT = true;
 
-    static CONSTRAINT_DEFAULT = true;
+  static TYPE_DEFAULT = 'xs:string';
 
-    static TYPE_DEFAULT = 'xs:string';
+  static get ACTION_ELEMENTS() {
+    return [
+      'FX-DELETE',
+      'FX-DISPATCH',
+      'FX-INSERT',
+      'FX-LOAD',
+      'FX-MESSAGE',
+      'FX-REBUILD',
+      'FX-RECALCULATE',
+      'FX-REFRESH',
+      'FX-RENEW',
+      'FX-REPLACE',
+      'FX-RESET',
+      'FX-RETAIN',
+      'FX-RETURN',
+      'FX-REVALIDATE',
+      'FX-SEND',
+      'FX-SETFOCUS',
+      'FX-SETINDEX',
+      'FX-SETVALUE',
+      'FX-TOGGLE',
+    ];
+  }
 
-
-    static get ACTION_ELEMENTS(){
-        return [
-            'FX-DELETE',
-            'FX-DISPATCH',
-            'FX-INSERT',
-            'FX-LOAD',
-            'FX-MESSAGE',
-            'FX-REBUILD',
-            'FX-RECALCULATE',
-            'FX-REFRESH',
-            'FX-RENEW',
-            'FX-REPLACE',
-            'FX-RESET',
-            'FX-RETAIN',
-            'FX-RETURN',
-            'FX-REVALIDATE',
-            'FX-SEND',
-            'FX-SETFOCUS',
-            'FX-SETINDEX',
-            'FX-SETVALUE',
-            'FX-TOGGLE',
-        ];
-    }
-
-    static namespaceResolver(prefix) {
-        // TODO: Do proper namespace resolving. Look at the ancestry / namespacesInScope of the declaration
-
-        /**
-         * for (let ancestor = this; ancestor; ancestor = ancestor.parentNode) {
-         * 	if (ancestor.getAttribute(`xmlns:${prefix}`)) {
-         *   // Return value
-         *  }
-         * }
-         */
-
-        // console.log('namespaceResolver  prefix', prefix);
-        const ns = {
-            'xhtml' : 'http://www.w3.org/1999/xhtml'
-            // ''    : Fore.XFORMS_NAMESPACE_URI
-        };
-        return ns[prefix] || null;
-    }
-
-	static get XFORMS_NAMESPACE_URI () {
-		return XFORMS_NAMESPACE_URI;
-	}
-
-    static isActionElement(elementName){
-        const found = Fore.ACTION_ELEMENTS.includes(elementName);
-        // console.log('isActionElement ', found);
-        return Fore.ACTION_ELEMENTS.includes(elementName);
-    }
-
-    static get UI_ELEMENTS(){
-        return [
-            'FX-ALERT',
-            'FX-CONTROL',
-            'FX-BUTTON',
-            'FX-CONTROL',
-            'FX-DIALOG',
-            'FX-FILENAME',
-            'FX-MEDIATYPE',
-            'FX-GROUP',
-            'FX-HINT',
-            'FX-INPUT',
-            'FX-ITEMSET',
-            'FX-LABEL',
-            'FX-OUTPUT',
-            'FX-RANGE',
-            'FX-REPEAT',
-            'FX-REPEATITEM',
-            'FX-SWITCH',
-            'FX-SECRET',
-            'FX-SELECT',
-            'FX-SUBMIT',
-            'FX-TEXTAREA',
-            'FX-TRIGGER',
-            'FX-UPLOAD'
-        ];
-    }
-
-
-    static isUiElement(elementName){
-        const found = Fore.UI_ELEMENTS.includes(elementName);
-        if(found){
-            // console.log('_isUiElement ', found);
-        }
-        return Fore.UI_ELEMENTS.includes(elementName);
-    }
-
-
-
-    // static async refreshChildren(startElement){
-    static async refreshChildren(startElement){
-
-        const refreshed = new Promise(((resolve,reject) => {
-            const {children} = startElement;
-            if(children){
-                Array.from(children).forEach(element => {
-
-                    // todo: later - check for AVTs
-                    if (Fore.isUiElement(element.nodeName) && typeof element.refresh === 'function') {
-                        element.refresh();
-                    }else if(element.nodeName !== 'fx-MODEL'){
-                            Fore.refreshChildren(element);
-                        }
-
-                });
-            }
-            resolve('done');
-        }));
-
-        return refreshed;
-    }
+  static namespaceResolver(prefix) {
+    // TODO: Do proper namespace resolving. Look at the ancestry / namespacesInScope of the declaration
 
     /**
-     * clear all text nodes and attribute values to get a 'clean' template.
-     * @param n
-     * @private
+     * for (let ancestor = this; ancestor; ancestor = ancestor.parentNode) {
+     * 	if (ancestor.getAttribute(`xmlns:${prefix}`)) {
+     *   // Return value
+     *  }
+     * }
      */
-    static clear(n){
-        n.textContent = '';
-        if(n.hasAttributes()){
-            const attrs = n.attributes;
-            for (let i = 0; i < attrs.length; i++) {
-                attrs[i].value = '';
-            }
-        }
-        const {children} = n;
-        for (let i = 0 ; i< children.length; i++){
-            Fore.clear(children[i]);
-        }
 
+    // console.log('namespaceResolver  prefix', prefix);
+    const ns = {
+      xhtml: 'http://www.w3.org/1999/xhtml',
+      // ''    : Fore.XFORMS_NAMESPACE_URI
+    };
+    return ns[prefix] || null;
+  }
+
+  static get XFORMS_NAMESPACE_URI() {
+    return XFORMS_NAMESPACE_URI;
+  }
+
+  static isActionElement(elementName) {
+    const found = Fore.ACTION_ELEMENTS.includes(elementName);
+    // console.log('isActionElement ', found);
+    return Fore.ACTION_ELEMENTS.includes(elementName);
+  }
+
+  static get UI_ELEMENTS() {
+    return [
+      'FX-ALERT',
+      'FX-CONTROL',
+      'FX-BUTTON',
+      'FX-CONTROL',
+      'FX-DIALOG',
+      'FX-FILENAME',
+      'FX-MEDIATYPE',
+      'FX-GROUP',
+      'FX-HINT',
+      'FX-INPUT',
+      'FX-ITEMSET',
+      'FX-LABEL',
+      'FX-OUTPUT',
+      'FX-RANGE',
+      'FX-REPEAT',
+      'FX-REPEATITEM',
+      'FX-SWITCH',
+      'FX-SECRET',
+      'FX-SELECT',
+      'FX-SUBMIT',
+      'FX-TEXTAREA',
+      'FX-TRIGGER',
+      'FX-UPLOAD',
+    ];
+  }
+
+  static isUiElement(elementName) {
+    const found = Fore.UI_ELEMENTS.includes(elementName);
+    if (found) {
+      // console.log('_isUiElement ', found);
     }
+    return Fore.UI_ELEMENTS.includes(elementName);
+  }
 
+  // static async refreshChildren(startElement){
+  static async refreshChildren(startElement) {
+    const refreshed = new Promise((resolve, reject) => {
+      const { children } = startElement;
+      if (children) {
+        Array.from(children).forEach(element => {
+          // todo: later - check for AVTs
+          if (Fore.isUiElement(element.nodeName) && typeof element.refresh === 'function') {
+            element.refresh();
+          } else if (element.nodeName !== 'fx-MODEL') {
+            Fore.refreshChildren(element);
+          }
+        });
+      }
+      resolve('done');
+    });
 
+    return refreshed;
+  }
+
+  /**
+   * clear all text nodes and attribute values to get a 'clean' template.
+   * @param n
+   * @private
+   */
+  static clear(n) {
+    n.textContent = '';
+    if (n.hasAttributes()) {
+      const attrs = n.attributes;
+      for (let i = 0; i < attrs.length; i++) {
+        attrs[i].value = '';
+      }
+    }
+    const { children } = n;
+    for (let i = 0; i < children.length; i++) {
+      Fore.clear(children[i]);
+    }
+  }
 }

--- a/src/fx-form.js
+++ b/src/fx-form.js
@@ -4,7 +4,7 @@ import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-dialog/paper-dialog.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@vaadin/vaadin-notification/vaadin-notification.js';
-import *  as  fx from 'fontoxpath';
+import * as fx from 'fontoxpath';
 import getInScopeContext from './getInScopeContext.js';
 import { Fore } from './fore.js';
 import './fx-instance.js';
@@ -21,32 +21,30 @@ import './fx-model.js';
  * This element uses LitElement as it uses shadowDOM to tempate global message dialogs
  */
 export class FxForm extends HTMLElement {
+  static get properties() {
+    return {
+      model: {
+        type: Object,
+      },
+      ready: {
+        type: Boolean,
+      },
+    };
+  }
 
+  constructor() {
+    super();
+    this.model = {};
+    this.addEventListener('model-construct-done', this._handleModelConstructDone);
+    this.addEventListener('message', this._displayMessage);
+    this.addEventListener('error', this._displayError);
+    window.addEventListener('compute-exception', e => {
+      console.error('circular dependency: ', e);
+    });
 
-    static get properties() {
-        return {
-            model:{
-                type: Object
-            },
-            ready:{
-                type:Boolean
-            }
-        };
-    }
+    this.ready = false;
 
-    constructor() {
-        super();
-        this.model = {};
-        this.addEventListener('model-construct-done', this._handleModelConstructDone);
-        this.addEventListener('message', this._displayMessage);
-        this.addEventListener('error', this._displayError);
-        window.addEventListener('compute-exception', e =>{
-            console.error("circular dependency: ", e);
-        });
-
-        this.ready = false;
-
-        const style = `
+    const style = `
             :host {
                 display: block;
                 height:auto;
@@ -62,7 +60,7 @@ export class FxForm extends HTMLElement {
             }
         `;
 
-        const html = `
+    const html = `
            <slot></slot>
            <paper-dialog id="modalMessage" modal="true">
                 <div id="messageContent"></div>
@@ -72,270 +70,259 @@ export class FxForm extends HTMLElement {
            </paper-dialog>
         `;
 
-        this.attachShadow({mode:'open'});
-        this.shadowRoot.innerHTML = `
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
             <style>
                 ${style}
             </style>
             ${html}
         `;
 
-        const slot = this.shadowRoot.querySelector('slot');
-        slot.addEventListener('slotchange', (event) => {
-            const children = event.target.assignedElements();
-            let model = children.find(model => model.nodeName.toUpperCase() === 'FX-MODEL');
-            if(!model){
-                const generatedModel = document.createElement('FX-model');
-                this.appendChild(generatedModel);
-                model=generatedModel;
-            }
-            if(!model.inited){
-                console.log('########## FORE: kick off processing... ##########');
-                model.modelConstruct();
-            }
-            this.model = model;
-        });
+    const slot = this.shadowRoot.querySelector('slot');
+    slot.addEventListener('slotchange', event => {
+      const children = event.target.assignedElements();
+      let model = children.find(model => model.nodeName.toUpperCase() === 'FX-MODEL');
+      if (!model) {
+        const generatedModel = document.createElement('FX-model');
+        this.appendChild(generatedModel);
+        model = generatedModel;
+      }
+      if (!model.inited) {
+        console.log('########## FORE: kick off processing... ##########');
+        model.modelConstruct();
+      }
+      this.model = model;
+    });
+  }
 
-    }
+  disconnectedCallback() {}
 
-    disconnectedCallback(){
-
-    }
-
-    /**
-     * refreshes the whole UI by visiting each bound element (having a 'ref' attribute) and applying the state of
-     * the bound modelItem to the bound element.
-     *
-     *
-     * AVT:
-     *
-     */
-    async refresh () {
+  /**
+   * refreshes the whole UI by visiting each bound element (having a 'ref' attribute) and applying the state of
+   * the bound modelItem to the bound element.
+   *
+   *
+   * AVT:
+   *
+   */
+  async refresh() {
     // refresh () {
-        console.group('### refresh');
-        const uiElements = this.querySelectorAll('*');
-        // await this.updateComplete;
+    console.group('### refresh');
+    const uiElements = this.querySelectorAll('*');
+    // await this.updateComplete;
 
-        // ### refresh template expressions
-        this._refreshTemplateExpressions();
+    // ### refresh template expressions
+    this._refreshTemplateExpressions();
 
-        Fore.refreshChildren(this);
-        // this.dispatchEvent(new CustomEvent('refresh-done', {detail:'foo'}));
-        console.groupEnd();
-        console.log('### <<<<< dispatching refresh-done - end of UI update cycle >>>>>');
-        this.dispatchEvent(new CustomEvent('refresh-done'));
+    Fore.refreshChildren(this);
+    // this.dispatchEvent(new CustomEvent('refresh-done', {detail:'foo'}));
+    console.groupEnd();
+    console.log('### <<<<< dispatching refresh-done - end of UI update cycle >>>>>');
+    this.dispatchEvent(new CustomEvent('refresh-done'));
+  }
+
+  /**
+   * entry point for processing of template expression enclosed in '{}' brackets.
+   *
+   * Expressions are found with an XPath search. For each node an entry is added to storedTemplateExpressions array.
+   *
+   *
+   * @private
+   */
+  _refreshTemplateExpressions() {
+    const search =
+      ".//*[name(.) != 'fx-model']/text()[contains(.,'{')] | .//*[name(.) != 'fx-model']/@*[contains(.,'{')]";
+    const tmplExpressions = fx.evaluateXPathToNodes(search, this, null, null);
+    console.log('template expressions found ', tmplExpressions);
+
+    if (!this.storedTemplateExpressions) {
+      this.storedTemplateExpressions = [];
     }
 
-    /**
-     * entry point for processing of template expression enclosed in '{}' brackets.
-     *
-     * Expressions are found with an XPath search. For each node an entry is added to storedTemplateExpressions array.
-     *
-     *
-     * @private
-     */
-    _refreshTemplateExpressions () {
-        const search = ".//*[name(.) != 'fx-model']/text()[contains(.,'{')] | .//*[name(.) != 'fx-model']/@*[contains(.,'{')]";
-        const tmplExpressions = fx.evaluateXPathToNodes(search,this,null,null);
-        console.log('template expressions found ', tmplExpressions);
+    const templateExpressions = [];
+    Array.from(tmplExpressions).forEach(node => {
+      // console.log('node ', node);
 
-        if(!this.storedTemplateExpressions){
-            this.storedTemplateExpressions=[];
-        }
+      let parent;
+      if (node.nodeType === Node.ATTRIBUTE_NODE) {
+        parent = node.ownerElement;
+      } else {
+        parent = node.parentNode;
+      }
+      // console.log('parent ', parent);
+      const expr = this._getTemplateExpression(node);
+      // console.log('expr ', expr);
 
-        const templateExpressions = [];
-        Array.from(tmplExpressions).forEach(node => {
-            // console.log('node ', node);
+      // ### store template expression
+      this.storedTemplateExpressions.push({
+        parent,
+        expr,
+        name: node.nodeName,
+        node,
+      });
+    });
 
-            let parent;
-            if(node.nodeType === Node.ATTRIBUTE_NODE){
-                parent = node.ownerElement;
-            }else{
-                parent = node.parentNode;
-            }
-            // console.log('parent ', parent);
-            const expr = this._getTemplateExpression(node);
-            // console.log('expr ', expr);
+    this.storedTemplateExpressions.forEach(tmpl => {
+      this._processTemplateExpression(tmpl);
+    });
 
-            // ### store template expression
-            this.storedTemplateExpressions.push({
-                'parent':parent,
-                'expr': expr,
-                'name': node.nodeName,
-                'node':node
-            });
+    console.log('stored template expressions ', this.storedTemplateExpressions);
+  }
+
+  _processTemplateExpression(exprObj) {
+    console.log('processing template expression ', exprObj);
+
+    const { parent } = exprObj;
+    const { expr } = exprObj;
+    const { name } = exprObj;
+    const { node } = exprObj;
+    console.log('expr ', expr);
+    const matches = expr.match(/{\w+}/g);
+    matches.forEach(match => {
+      console.log('match ', match);
+      const naked = match.substring(1, match.length - 1);
+      const inscope = getInScopeContext(node, naked);
+      const result = fx.evaluateXPathToString(naked, inscope, null, {
+        namespaceResolver: Fore.namespaceResolver,
+      });
+      // console.log('result of eval ', result);
+      const replaced = expr.replaceAll(match, result);
+      console.log('result of replacing ', replaced);
+
+      if (node.nodeType === Node.ATTRIBUTE_NODE) {
+        parent.setAttribute(name, replaced);
+      } else if (node.nodeType === Node.TEXT_NODE) {
+        node.textContent = replaced;
+      }
+    });
+  }
+
+  _getTemplateExpression(node) {
+    if (node.nodeType === Node.ATTRIBUTE_NODE) {
+      return node.value;
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent;
+    }
+    return null;
+  }
+
+  _refreshChildren() {
+    const uiElements = this.querySelectorAll('*');
+
+    uiElements.forEach(element => {
+      if (Fore.isUiElement(element.nodeName) && typeof element.refresh === 'function') {
+        element.refresh();
+      }
+    });
+  }
+
+  _handleModelConstructDone(e) {
+    this._initUI();
+  }
+
+  async _lazyCreateInstance() {
+    const model = this.querySelector('fx-model');
+    if (model.instances.length === 0) {
+      console.log('### lazy creation of instance');
+      const generatedInstance = document.createElement('fx-instance');
+      model.appendChild(generatedInstance);
+
+      const generated = document.implementation.createDocument(null, 'data');
+      const newData = this._generateInstance(this, generated.firstElementChild);
+      generatedInstance.instanceData = generated;
+      model.instances.push(generatedInstance);
+    }
+  }
+
+  /**
+   * @param {Element} start
+   * @param {Element} parent
+   */
+  _generateInstance(start, parent) {
+    if (start.hasAttribute('ref')) {
+      const ref = start.getAttribute('ref');
+      // const generated = document.createElement(ref);
+      const generated = parent.ownerDocument.createElement(ref);
+      if (start.children.length === 0) {
+        generated.textContent = start.textContent;
+      }
+      parent.appendChild(generated);
+      parent = generated;
+    }
+
+    if (start.hasChildNodes()) {
+      const list = start.children;
+      for (let i = 0; i < list.length; i++) {
+        this._generateInstance(list[i], parent);
+      }
+    }
+    return parent;
+  }
+
+  async _initUI() {
+    console.log('### _initUI()');
+
+    await this._lazyCreateInstance();
+    await this.refresh();
+    this.ready = true;
+    console.log('### <<<<< dispatching ready >>>>>');
+    console.log('########## FORE: form fully initialized... ##########');
+    this.dispatchEvent(new CustomEvent('ready', {}));
+  }
+
+  getModel() {
+    return this.querySelector('fx-model');
+  }
+
+  _displayMessage(e) {
+    const { level } = e.detail;
+    const msg = e.detail.message;
+    this._showMessage(level, msg);
+  }
+
+  _displayError(e) {
+    const { error } = e.detail;
+    const msg = e.detail.message;
+    this._showMessage('modal', msg);
+  }
+
+  _showMessage(level, msg) {
+    if (level === 'modal') {
+      // this.$.messageContent.innerText = msg;
+      // this.$.modalMessage.open();
+
+      this.shadowRoot.getElementById('messageContent').innerText = msg;
+      this.shadowRoot.getElementById('modalMessage').open();
+    } else if (level === 'modeless') {
+      // const notification = this.$.modeless;
+
+      const notification = document.createElement('vaadin-notification');
+      notification.duration = 0;
+      notification.setAttribute('theme', 'error');
+      notification.renderer = function(root) {
+        // console.log('root ', root);
+
+        root.textContent = msg;
+
+        const closeIcon = window.document.createElement('paper-icon-button');
+        closeIcon.setAttribute('icon', 'close');
+        closeIcon.addEventListener('click', e => {
+          // console.log(e);
+          notification.close();
         });
-
-        this.storedTemplateExpressions.forEach(tmpl => {
-           this._processTemplateExpression(tmpl);
-        });
-
-        console.log('stored template expressions ', this.storedTemplateExpressions);
+        root.appendChild(closeIcon);
+      };
+      this.appendChild(notification);
+      notification.open();
+    } else {
+      const notification = document.createElement('vaadin-notification');
+      notification.renderer = function(root) {
+        root.textContent = msg;
+      };
+      this.appendChild(notification);
+      notification.open();
     }
-
-    _processTemplateExpression (exprObj) {
-        console.log('processing template expression ', exprObj);
-
-        const {parent} = exprObj;
-        const {expr} = exprObj;
-        const {name} = exprObj;
-        const {node} = exprObj;
-        console.log('expr ', expr);
-        const matches = expr.match(/{\w+}/g);
-        matches.forEach(match => {
-            console.log('match ', match);
-            const naked = match.substring(1,match.length-1);
-            const inscope = getInScopeContext(node,naked);
-            const result = fx.evaluateXPathToString(naked, inscope, null, {namespaceResolver:  Fore.namespaceResolver});
-            // console.log('result of eval ', result);
-            const replaced = expr.replaceAll(match,result);
-            console.log('result of replacing ', replaced);
-
-            if(node.nodeType === Node.ATTRIBUTE_NODE){
-                parent.setAttribute(name,replaced);
-            }else if(node.nodeType === Node.TEXT_NODE){
-                node.textContent = replaced;
-            }
-
-
-        });
-    }
-
-    _getTemplateExpression(node){
-        if(node.nodeType === Node.ATTRIBUTE_NODE){
-            return node.value;
-        }if(node.nodeType === Node.TEXT_NODE){
-            return node.textContent;
-        }
-            return null;
-
-    }
-
-    _refreshChildren(){
-        const uiElements = this.querySelectorAll('*');
-
-        uiElements.forEach(element => {
-
-            if (Fore.isUiElement(element.nodeName) && typeof element.refresh === 'function') {
-                element.refresh();
-            }
-
-        });
-
-    }
-
-    _handleModelConstructDone(e){
-        this._initUI();
-    }
-
-    async _lazyCreateInstance(){
-        const model = this.querySelector('fx-model');
-        if(model.instances.length === 0){
-            console.log('### lazy creation of instance');
-            const generatedInstance = document.createElement('fx-instance');
-            model.appendChild(generatedInstance);
-
-            const generated = document.implementation.createDocument(null, "data");
-            const newData = this._generateInstance(this, generated.firstElementChild);
-            generatedInstance.instanceData = generated;
-            model.instances.push(generatedInstance);
-        }
-    }
-
-    /**
-     * @param {Element} start
-     * @param {Element} parent
-     */
-    _generateInstance(start, parent){
-
-        if(start.hasAttribute('ref')){
-            const ref = start.getAttribute('ref');
-            // const generated = document.createElement(ref);
-            const generated = parent.ownerDocument.createElement(ref);
-            if(start.children.length === 0){
-                generated.textContent = start.textContent;
-            }
-            parent.appendChild(generated);
-            parent=generated;
-        }
-
-        if(start.hasChildNodes()){
-            const list = start.children;
-            for(let i=0; i < list.length; i++){
-                this._generateInstance(list[i],parent)
-            }
-        }
-        return parent;
-    }
-
-
-
-     async _initUI(){
-        console.log('### _initUI()');
-
-         await this._lazyCreateInstance();
-         await this.refresh();
-         this.ready = true;
-         console.log('### <<<<< dispatching ready >>>>>');
-         console.log('########## FORE: form fully initialized... ##########');
-         this.dispatchEvent(new CustomEvent('ready', {}));
-     }
-
-     getModel(){
-        return this.querySelector('fx-model');
-     }
-
-    _displayMessage(e) {
-        const {level} = e.detail;
-        const msg = e.detail.message;
-        this._showMessage(level,msg);
-    }
-
-    _displayError(e){
-        const {error} = e.detail;
-        const msg = e.detail.message;
-        this._showMessage('modal',msg);
-    }
-
-    _showMessage(level, msg){
-        if (level === 'modal') {
-            // this.$.messageContent.innerText = msg;
-            // this.$.modalMessage.open();
-
-            this.shadowRoot.getElementById('messageContent').innerText = msg;
-            this.shadowRoot.getElementById('modalMessage').open();
-        } else if (level === 'modeless') {
-            // const notification = this.$.modeless;
-
-            const notification = document.createElement('vaadin-notification');
-            notification.duration = 0;
-            notification.setAttribute('theme', 'error');
-            notification.renderer = function (root) {
-                // console.log('root ', root);
-
-                root.textContent = msg;
-
-                const closeIcon = window.document.createElement('paper-icon-button');
-                closeIcon.setAttribute('icon', 'close');
-                closeIcon.addEventListener('click', (e) => {
-                    // console.log(e);
-                    notification.close();
-                });
-                root.appendChild(closeIcon);
-            };
-            this.appendChild(notification);
-            notification.open();
-
-        } else {
-            const notification = document.createElement('vaadin-notification');
-            notification.renderer = function (root) {
-                root.textContent = msg;
-            };
-            this.appendChild(notification);
-            notification.open();
-        }
-
-    }
-
+  }
 }
 customElements.define('fx-form', FxForm);

--- a/src/fx-instance.js
+++ b/src/fx-instance.js
@@ -3,35 +3,33 @@ import '@polymer/iron-ajax/iron-ajax.js';
 import * as fx from 'fontoxpath';
 
 export class FxInstance extends HTMLElement {
+  constructor() {
+    super();
 
-    constructor() {
-        super();
+    this.model = this.parentNode;
 
-        this.model = this.parentNode;
+    this.attachShadow({ mode: 'open' });
+  }
 
-        this.attachShadow({mode:'open'});
+  connectedCallback() {
+    // console.log('connectedCallback ', this);
+    if (this.hasAttribute('src')) {
+      this.src = this.getAttribute('src');
+    }
+    // this.src = '';
 
+    if (this.hasAttribute('id')) {
+      this.id = this.getAttribute('id');
+    } else {
+      this.id = 'default';
     }
 
-    connectedCallback(){
-        // console.log('connectedCallback ', this);
-        if(this.hasAttribute('src')){
-            this.src=this.getAttribute('src');
-        }
-        // this.src = '';
-
-        if(this.hasAttribute('id')){
-            this.id = this.getAttribute('id');
-        }else{
-            this.id = 'default';
-        }
-
-        if(this.hasAttribute('type')){
-            this.type = this.getAttribute('type');
-        }else {
-            this.type = 'xml';
-        }
-        const style = `
+    if (this.hasAttribute('type')) {
+      this.type = this.getAttribute('type');
+    } else {
+      this.type = 'xml';
+    }
+    const style = `
             :host {
                 display: none;
             }
@@ -40,7 +38,7 @@ export class FxInstance extends HTMLElement {
             }
         `;
 
-        const html = `
+    const html = `
            <iron-ajax
                 id="loader"
                 url="${this.src}"
@@ -48,137 +46,131 @@ export class FxInstance extends HTMLElement {
                 handle-as="text"
                 with-credentials></iron-ajax>
         `;
-        this.shadowRoot.innerHTML = `
+    this.shadowRoot.innerHTML = `
             <style>
                 ${style}
             </style>
             ${html}
         `;
-    }
+  }
 
-    async init (){
-        // console.log('fx-instance init');
-        // if(this.src) return;
-        if(this.type === 'xml'){
-            await this._initXMLInstance();
-        }else{
-            this._initJSONInstance();
+  async init() {
+    // console.log('fx-instance init');
+    // if(this.src) return;
+    if (this.type === 'xml') {
+      await this._initXMLInstance();
+    } else {
+      this._initJSONInstance();
+    }
+    return this;
+    // this.shadowRoot.getElementById('data').appendChild(this.instanceData.cloneNode(true));
+  }
+
+  evalXPath(xpath) {
+    const result = fx.evaluateXPathToFirstNode(xpath, this.getDefaultContext(), null, {});
+    return result;
+  }
+
+  getInstanceData() {
+    return this.instanceData;
+  }
+
+  getDefaultContext() {
+    // console.log('getDefaultContext ', this.instanceData.firstElementChild);
+    if (this.type === 'xml') {
+      return this.instanceData.firstElementChild;
+    }
+    return this.instanceData;
+  }
+
+  _initXMLInstance() {
+    const loadedPromise = new Promise((resolve, reject) => {
+      // setTimeout(() => resolve("done"), 2000);
+
+      if (this.src === '#querystring') {
+        const query = new URLSearchParams(location.search);
+        // console.log('query', query);
+
+        const doc = new DOMParser().parseFromString('<data></data>', 'application/xml');
+        const root = doc.firstElementChild;
+        for (const p of query) {
+          const newNode = doc.createElement(p[0]);
+          newNode.appendChild(doc.createTextNode(p[1]));
+          root.appendChild(newNode);
         }
-        return this;
-        // this.shadowRoot.getElementById('data').appendChild(this.instanceData.cloneNode(true));
-    }
 
-    evalXPath(xpath){
-        const result = fx.evaluateXPathToFirstNode(xpath, this.getDefaultContext(), null, {});
-        return result;
-    }
+        this.instanceData = doc;
+        this.instanceData.firstElementChild.setAttribute('id', this.id);
 
+        // const data = new XMLSerializer().serializeToString(this.instanceData);
+        // console.log('instance from querystring ' , data);
 
-    getInstanceData(){
-        return this.instanceData;
-    }
-
-    getDefaultContext(){
-        // console.log('getDefaultContext ', this.instanceData.firstElementChild);
-        if(this.type === 'xml'){
-            return this.instanceData.firstElementChild;
-        }
-            return this.instanceData;
-
-    }
-
-    _initXMLInstance(){
-        const loadedPromise = new Promise(((resolve,reject) => {
-            // setTimeout(() => resolve("done"), 2000);
-
-            if(this.src === '#querystring' ){
-                const query = new URLSearchParams(location.search);
-                // console.log('query', query);
-
-                const doc = new DOMParser().parseFromString('<data></data>','application/xml');
-                const root = doc.firstElementChild;
-                for(const p of query){
-                    const newNode = doc.createElement(p[0]);
-                    newNode.appendChild(doc.createTextNode(p[1]));
-                    root.appendChild(newNode);
-                }
-
-                this.instanceData = doc;
-                this.instanceData.firstElementChild.setAttribute('id',this.id);
-
-                // const data = new XMLSerializer().serializeToString(this.instanceData);
-                // console.log('instance from querystring ' , data);
-
-                resolve("done");
-            } else if(this.src){
-
-                const loader = this.shadowRoot.getElementById('loader');
-                loader.addEventListener('response',() => {
-                    const instanceData = new DOMParser().parseFromString(loader.lastResponse,'application/xml');
-                    this.instanceData = instanceData;
-                    console.log('fx-instance data: ', this.instanceData);
-                    this.dispatchEvent(new CustomEvent('instance-loaded', {}));
-                    resolve("done");
-                });
-                loader.addEventListener('error',() =>{
-                    console.log('error while loading data from src: ', loader.lastError);
-                    reject();
-                });
-                loader.generateRequest();
-
-            } else if(this.childNodes.length !== 0){
-                // setTimeout(() => resolve("done"), 2000);
-                // var foo = this;
-                // setTimeout(function(){
-                //     foo._useInlineData();
-                //     resolve("done");
-                // },10000);
-
-                this._useInlineData();
-                resolve("done");
-            }
-
-        }));
-        return loadedPromise;
-    }
-
-    _initJSONInstance(){
-        this.instanceData = JSON.parse(this.textContent);
-    }
-
-    _useInlineData(){
-        // console.log('innerText ', this.innerHTML.toString());
-        const instanceData = new DOMParser().parseFromString(this.innerHTML,'application/xml');
-
-        // console.log('created instanceData ', new XMLSerializer().serializeToString(instanceData));
-        // console.log('namespace ', instanceData.firstElementChild.namespaceURI);
-
-        console.log('fx-instance init id:', this.id);
-        this.instanceData = instanceData;
-        // console.log('instanceData ', this.instanceData);
-        // console.log('instanceData ', this.instanceData.firstElementChild);
-        // this.shadowRoot.appendChild(this.instanceData.firstElementChild);
-
-        console.log('fx-instance data: ', this.instanceData);
-        this.instanceData.firstElementChild.setAttribute('id',this.id);
-        // console.log('fx-instance data ', this.instanceData);
-    }
-
-    _handleResponse(){
-        console.log('_handleResponse ');
-        const ajax = this.shadowRoot.getElementById('loader');
-        const instanceData = new DOMParser().parseFromString(ajax.lastResponse,'application/xml');
-        this.instanceData = instanceData;
-        console.log('data: ', this.instanceData);
-
-    }
-
-    _handleError(){
+        resolve('done');
+      } else if (this.src) {
         const loader = this.shadowRoot.getElementById('loader');
-        console.log('_handleResponse ', loader.lastError);
+        loader.addEventListener('response', () => {
+          const instanceData = new DOMParser().parseFromString(
+            loader.lastResponse,
+            'application/xml',
+          );
+          this.instanceData = instanceData;
+          console.log('fx-instance data: ', this.instanceData);
+          this.dispatchEvent(new CustomEvent('instance-loaded', {}));
+          resolve('done');
+        });
+        loader.addEventListener('error', () => {
+          console.log('error while loading data from src: ', loader.lastError);
+          reject();
+        });
+        loader.generateRequest();
+      } else if (this.childNodes.length !== 0) {
+        // setTimeout(() => resolve("done"), 2000);
+        // var foo = this;
+        // setTimeout(function(){
+        //     foo._useInlineData();
+        //     resolve("done");
+        // },10000);
 
-    }
+        this._useInlineData();
+        resolve('done');
+      }
+    });
+    return loadedPromise;
+  }
 
+  _initJSONInstance() {
+    this.instanceData = JSON.parse(this.textContent);
+  }
 
+  _useInlineData() {
+    // console.log('innerText ', this.innerHTML.toString());
+    const instanceData = new DOMParser().parseFromString(this.innerHTML, 'application/xml');
+
+    // console.log('created instanceData ', new XMLSerializer().serializeToString(instanceData));
+    // console.log('namespace ', instanceData.firstElementChild.namespaceURI);
+
+    console.log('fx-instance init id:', this.id);
+    this.instanceData = instanceData;
+    // console.log('instanceData ', this.instanceData);
+    // console.log('instanceData ', this.instanceData.firstElementChild);
+    // this.shadowRoot.appendChild(this.instanceData.firstElementChild);
+
+    console.log('fx-instance data: ', this.instanceData);
+    this.instanceData.firstElementChild.setAttribute('id', this.id);
+    // console.log('fx-instance data ', this.instanceData);
+  }
+
+  _handleResponse() {
+    console.log('_handleResponse ');
+    const ajax = this.shadowRoot.getElementById('loader');
+    const instanceData = new DOMParser().parseFromString(ajax.lastResponse, 'application/xml');
+    this.instanceData = instanceData;
+    console.log('data: ', this.instanceData);
+  }
+
+  _handleError() {
+    const loader = this.shadowRoot.getElementById('loader');
+    console.log('_handleResponse ', loader.lastError);
+  }
 }
 customElements.define('fx-instance', FxInstance);

--- a/src/fx-model.js
+++ b/src/fx-model.js
@@ -1,255 +1,269 @@
-import DepGraph from "./dep_graph.js";
+import DepGraph from './dep_graph.js';
 import { Fore } from './fore.js';
 import './fx-instance.js';
-import { ModelItem } from "./modelitem.js";
+import { ModelItem } from './modelitem.js';
 import { evaluateXPath, evaluateXPathToBoolean } from './xpath-evaluation';
 import { XPathUtil } from './xpath-util.js';
 
 export class FxModel extends HTMLElement {
+  constructor() {
+    super();
+    // this.id = '';
+    this.instances = [];
+    this.modelItems = [];
+    this.defaultContext = {};
 
-    constructor() {
-        super();
-        // this.id = '';
-        this.instances = [];
-        this.modelItems = [];
-        this.defaultContext = {};
+    this.mainGraph = new DepGraph(false);
+    this.inited = false;
+    this.attachShadow({ mode: 'open' });
+  }
 
-        this.mainGraph = new DepGraph(false);
-        this.inited = false;
-        this.attachShadow({mode:'open'});
-    }
+  get formElement() {
+    return this.parentElement;
+  }
 
-    get formElement(){
-        return this.parentElement;
-    }
-
-    connectedCallback() {
-        // console.log('connectedCallback ', this);
-        this.shadowRoot.innerHTML = `
+  connectedCallback() {
+    // console.log('connectedCallback ', this);
+    this.shadowRoot.innerHTML = `
             <slot></slot>
         `;
+  }
+
+  static lazyCreateModelItem(model, ref, node) {
+    // console.log('lazyCreateModelItem ', node);
+
+    let targetNode = {};
+    if (node === null) return null;
+    if (node.nodeType === node.TEXT_NODE) {
+      // const parent = node.parentNode;
+      // console.log('PARENT ', parent);
+      targetNode = node.parentNode;
+    } else {
+      targetNode = node;
     }
 
-    static lazyCreateModelItem(model,ref,node){
-        // console.log('lazyCreateModelItem ', node);
+    // const path = fx.evaluateXPath('path()',node);
+    const path = XPathUtil.getPath(node);
 
-        let targetNode = {};
-        if(node === null) return null;
-        if(node.nodeType === node.TEXT_NODE){
-            // const parent = node.parentNode;
-            // console.log('PARENT ', parent);
-            targetNode = node.parentNode;
-        }else {
-            targetNode = node;
+    // ### intializing ModelItem with default values (as there is no <fx-bind> matching for given ref)
+    const mi = new ModelItem(
+      path,
+      ref,
+      Fore.READONLY_DEFAULT,
+      Fore.RELEVANT_DEFAULT,
+      Fore.REQUIRED_DEFAULT,
+      Fore.CONSTRAINT_DEFAULT,
+      Fore.TYPE_DEFAULT,
+      targetNode,
+      this,
+    );
+
+    // console.log('new ModelItem is instanceof ModelItem ', mi instanceof ModelItem);
+    model.registerModelItem(mi);
+    return mi;
+  }
+
+  modelConstruct() {
+    console.log('### <<<<< dispatching model-construct >>>>>');
+    this.dispatchEvent(new CustomEvent('model-construct', { detail: this }));
+
+    const instances = this.querySelectorAll('fx-instance');
+    if (instances.length > 0) {
+      console.group('init instances');
+      const promises = [];
+      instances.forEach(instance => {
+        promises.push(instance.init());
+      });
+
+      Promise.all(promises).then(result => {
+        this.instances = Array.from(instances);
+        console.log('_modelConstruct this.instances ', this.instances);
+        this.updateModel();
+        this.inited = true;
+
+        console.log('### <<<<< dispatching model-construct-done >>>>>');
+        this.dispatchEvent(
+          new CustomEvent('model-construct-done', {
+            composed: true,
+            bubbles: true,
+            detail: { model: this },
+          }),
+        );
+      });
+      console.groupEnd();
+    } else {
+      // ### if there's no instance one will created
+      this.dispatchEvent(
+        new CustomEvent('model-construct-done', {
+          composed: true,
+          bubbles: true,
+          detail: { model: this },
+        }),
+      );
+    }
+    this.inited = true;
+  }
+
+  registerModelItem(modelItem) {
+    // console.log('ModelItem registered ', modelItem);
+    this.modelItems.push(modelItem);
+  }
+
+  /**
+   * update action triggering the update cycle
+   */
+  updateModel() {
+    this.rebuild();
+    this.recalculate();
+    this.revalidate();
+  }
+
+  rebuild() {
+    console.group('### rebuild');
+
+    this.modelItems = [];
+
+    // trigger recursive initialization of the fx-bind elements
+    const binds = this.querySelectorAll('fx-model > fx-bind');
+    binds.forEach(bind => {
+      bind.init(this);
+    });
+
+    // console.log(`dependencies of a `, this.mainGraph.dependenciesOf("/Q{}data[1]/Q{}a[1]:required"));
+    // console.log(`dependencies of b `, this.mainGraph.dependenciesOf("/Q{}data[1]/Q{}b[1]:required"));
+    console.log(`rebuild mainGraph`, this.mainGraph);
+    console.log(`rebuild mainGraph calc order`, this.mainGraph.overallOrder());
+    console.log(
+      `rebuild finished with modelItems ${this.modelItems.length} item(s)`,
+      this.modelItems,
+    );
+    console.groupEnd();
+  }
+
+  /**
+   * recalculation of all modelItems. Uses dependency graph to determine order of computation.
+   *
+   * todo: use 'changed' flag on modelItems to determine subgraph for recalculation. Flag already exists but is not used.
+   */
+  recalculate() {
+    console.group('### recalculate');
+
+    const v = this.mainGraph.overallOrder();
+    v.forEach(path => {
+      // console.log('recalculating path ', path);
+
+      const node = this.mainGraph.getNodeData(path);
+      // console.log('recalculating node ', node);
+      const modelItem = this.getModelItem(node);
+      // console.log('modelitem ', modelItem);
+
+      if (modelItem && path.indexOf(':')) {
+        const property = path.split(':')[1];
+        if (property) {
+          if (property === 'calculate') {
+            const expr = modelItem.bind[property];
+            const compute = evaluateXPath(expr, modelItem.node, this, Fore.namespaceResolver);
+            modelItem.value = compute;
+          } else if (property !== 'constraint' && property !== 'type') {
+            // console.log('recalculating property ', property);
+
+            const expr = modelItem.bind[property];
+            if (expr) {
+              // console.log('recalc expr: ', expr);
+              const compute = evaluateXPathToBoolean(
+                expr,
+                modelItem.node,
+                this,
+                Fore.namespaceResolver,
+              );
+              modelItem[property] = compute;
+              // console.log(`modelItem computed`, modelItem.required);
+            }
+          }
         }
+      }
+    });
+    console.log(
+      `recalculate finished with modelItems ${this.modelItems.length} item(s)`,
+      this.modelItems,
+    );
+    console.groupEnd();
+  }
 
-        // const path = fx.evaluateXPath('path()',node);
-        const path = XPathUtil.getPath(node);
+  revalidate() {
+    console.group('### revalidate');
 
-        // ### intializing ModelItem with default values (as there is no <fx-bind> matching for given ref)
-        const mi = new ModelItem(path,
-            ref,
-            Fore.READONLY_DEFAULT,
-            Fore.RELEVANT_DEFAULT,
-            Fore.REQUIRED_DEFAULT,
-            Fore.CONSTRAINT_DEFAULT,
-            Fore.TYPE_DEFAULT,
-            targetNode,
-            this);
+    this.modelItems.forEach(modelItem => {
+      // console.log('validating node ', modelItem.node);
+      modelItem.alerts = []; // reset alerts
 
+      const { bind } = modelItem;
+      if (bind) {
+        // console.log('modelItem bind ', bind);
 
-        // console.log('new ModelItem is instanceof ModelItem ', mi instanceof ModelItem);
-        model.registerModelItem(mi);
-        return mi;
-    }
+        // todo: investigate why bind is an element when created in fx-bind.init() and an ...
+        // fx-bind object when created lazily.
 
-
-    modelConstruct() {
-        console.log('### <<<<< dispatching model-construct >>>>>');
-        this.dispatchEvent(new CustomEvent('model-construct', { detail: this}));
-
-            const instances = this.querySelectorAll('fx-instance');
-            if (instances.length > 0) {
-                console.group('init instances');
-                const promises = [];
-                instances.forEach(instance => {
-                    promises.push(instance.init())
-                });
-
-                Promise.all(promises).then( result => {
-                    this.instances = Array.from(instances);
-                    console.log('_modelConstruct this.instances ', this.instances);
-                    this.updateModel();
-                    this.inited = true;
-
-                    console.log('### <<<<< dispatching model-construct-done >>>>>');
-                    this.dispatchEvent(new CustomEvent('model-construct-done', {
-                        composed: true,
-                        bubbles: true,
-                        detail: {model: this}
-                    }));
-
-                });
-                console.groupEnd();
-
-            } else {
-                // ### if there's no instance one will created
-                this.dispatchEvent(new CustomEvent('model-construct-done', {
-                    composed: true,
-                    bubbles: true,
-                    detail: {model: this}
-                }));
+        if (typeof bind.hasAttribute === 'function' && bind.hasAttribute('constraint')) {
+          const constraint = bind.getAttribute('constraint');
+          if (constraint) {
+            const compute = evaluateXPathToBoolean(
+              constraint,
+              modelItem.node,
+              this,
+              Fore.namespaceResolver,
+            );
+            console.log('modelItem validity computed: ', compute);
+            modelItem.constraint = compute;
+            if (!compute) {
+              // todo: get alert from attribute or child element
+              const alert = bind.getAlert();
+              modelItem.addAlert(alert);
             }
-            this.inited = true;
+          }
+        }
+      }
+    });
+    console.log('modelItems after revalidate: ', this.modelItems);
+    console.groupEnd();
+  }
 
-    }
+  getModelItem(node) {
+    return this.modelItems.find(m => m.node === node);
+  }
 
-    registerModelItem(modelItem) {
-        // console.log('ModelItem registered ', modelItem);
-        this.modelItems.push(modelItem);
-    }
+  /**
+   * get the default evaluation context for this model.
+   * @returns {Element} the
+   */
+  getDefaultContext() {
+    return this.instances[0].getDefaultContext();
+  }
 
-    /**
-     * update action triggering the update cycle
-     */
-    updateModel() {
-        this.rebuild();
-        this.recalculate();
-        this.revalidate();
-    }
+  getDefaultInstance() {
+    return this.instances[0];
+  }
 
-    rebuild() {
-        console.group('### rebuild');
+  getDefaultInstanceData() {
+    console.log('default instance data ', this.instances[0].instanceData);
+    return this.instances[0].instanceData;
+  }
 
-        this.modelItems = [];
+  getInstance(id) {
+    // console.log('getInstance ', id);
+    // console.log('instances ', this.instances);
+    // console.log('instances array ',Array.from(this.instances));
 
-        // trigger recursive initialization of the fx-bind elements
-        const binds = this.querySelectorAll('fx-model > fx-bind');
-        binds.forEach(bind => {
-            bind.init(this);
-        });
+    const instArray = Array.from(this.instances);
+    return instArray.find(inst => inst.id === id);
+  }
 
-        // console.log(`dependencies of a `, this.mainGraph.dependenciesOf("/Q{}data[1]/Q{}a[1]:required"));
-        // console.log(`dependencies of b `, this.mainGraph.dependenciesOf("/Q{}data[1]/Q{}b[1]:required"));
-        console.log(`rebuild mainGraph`, this.mainGraph);
-        console.log(`rebuild mainGraph calc order`, this.mainGraph.overallOrder());
-        console.log(`rebuild finished with modelItems ${this.modelItems.length} item(s)`, this.modelItems);
-        console.groupEnd();
-    }
-
-    /**
-     * recalculation of all modelItems. Uses dependency graph to determine order of computation.
-     *
-     * todo: use 'changed' flag on modelItems to determine subgraph for recalculation. Flag already exists but is not used.
-     */
-    recalculate() {
-        console.group('### recalculate');
-
-        const v = this.mainGraph.overallOrder();
-        v.forEach(path => {
-            // console.log('recalculating path ', path);
-
-            const node = this.mainGraph.getNodeData(path);
-            // console.log('recalculating node ', node);
-            const modelItem = this.getModelItem(node);
-            // console.log('modelitem ', modelItem);
-
-            if (modelItem && path.indexOf(':')) {
-                const property = path.split(':')[1];
-                if (property) {
-                    if (property === 'calculate') {
-                        const expr = modelItem.bind[property];
-                        const compute = evaluateXPath(expr, modelItem.node, this, Fore.namespaceResolver);
-                        modelItem.value = compute;
-                    } else if (property !== 'constraint' && property !== 'type') {
-                        // console.log('recalculating property ', property);
-
-                        const expr = modelItem.bind[property];
-                        if (expr) {
-                            // console.log('recalc expr: ', expr);
-                            const compute = evaluateXPathToBoolean(expr, modelItem.node, this, Fore.namespaceResolver);
-                            modelItem[property] = compute;
-                            // console.log(`modelItem computed`, modelItem.required);
-                        }
-                    }
-                }
-            }
-        })
-        console.log(`recalculate finished with modelItems ${this.modelItems.length} item(s)`, this.modelItems);
-        console.groupEnd();
-    }
-
-    revalidate() {
-        console.group('### revalidate');
-
-        this.modelItems.forEach(modelItem => {
-            // console.log('validating node ', modelItem.node);
-            modelItem.alerts=[];// reset alerts
-
-            const {bind} = modelItem;
-            if (bind) {
-                // console.log('modelItem bind ', bind);
-
-                // todo: investigate why bind is an element when created in fx-bind.init() and an ...
-                // fx-bind object when created lazily.
-
-                if (typeof bind.hasAttribute === "function" && bind.hasAttribute('constraint')) {
-                    const constraint = bind.getAttribute('constraint');
-                    if (constraint) {
-                        const compute = evaluateXPathToBoolean(constraint, modelItem.node, this, Fore.namespaceResolver);
-                        console.log('modelItem validity computed: ', compute);
-                        modelItem.constraint = compute;
-                        if (!compute) {
-                            // todo: get alert from attribute or child element
-                            const alert = bind.getAlert();
-                            modelItem.addAlert(alert);
-
-                        }
-                    }
-                }
-            }
-        });
-        console.log('modelItems after revalidate: ', this.modelItems);
-        console.groupEnd();
-    }
-
-    getModelItem(node) {
-        return this.modelItems.find(m => m.node === node);
-    }
-
-    /**
-     * get the default evaluation context for this model.
-     * @returns {Element} the
-     */
-    getDefaultContext() {
-        return this.instances[0].getDefaultContext();
-    }
-
-    getDefaultInstance() {
-        return this.instances[0];
-    }
-
-    getDefaultInstanceData() {
-        console.log('default instance data ', this.instances[0].instanceData);
-        return this.instances[0].instanceData;
-    }
-
-    getInstance(id) {
-        // console.log('getInstance ', id);
-        // console.log('instances ', this.instances);
-        // console.log('instances array ',Array.from(this.instances));
-
-        const instArray = Array.from(this.instances);
-        return instArray.find(inst => inst.id === id);
-    }
-
-    evalBinding(bindingExpr) {
-        // console.log('MODEL.evalBinding ', bindingExpr);
-        // default context of evaluation is always the default instance
-        const result = this.instances[0].evalXPath(bindingExpr);
-        return result;
-    }
-
+  evalBinding(bindingExpr) {
+    // console.log('MODEL.evalBinding ', bindingExpr);
+    // default context of evaluation is always the default instance
+    const result = this.instances[0].evalXPath(bindingExpr);
+    return result;
+  }
 }
 
 customElements.define('fx-model', FxModel);

--- a/src/fx-submission.js
+++ b/src/fx-submission.js
@@ -1,167 +1,162 @@
-import {LitElement, html, css} from 'lit-element';
+import { LitElement, html, css } from 'lit-element';
 import '@polymer/iron-ajax/iron-ajax.js';
 
 // import * as fx from 'fontoxpath';
-import {foreElementMixin} from "./ForeElementMixin";
+import { foreElementMixin } from './ForeElementMixin';
 
-export class FxSubmission extends foreElementMixin(LitElement){
+export class FxSubmission extends foreElementMixin(LitElement) {
+  static get styles() {
+    return css`
+      :host {
+        display: none;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-            :host {
-                display: none;
-            }
-        `;
+  static get properties() {
+    return {
+      ...super.properties,
+      id: {
+        type: String,
+      },
+      /**
+       * submission method - one of GET, POST, PUT, DELETE (HEAD?)
+       */
+      method: {
+        type: String,
+      },
+      nonrelevant: {
+        type: String,
+      },
+      /**
+       * what to do with the submission response. Either 'none' or 'instance' for now.
+       */
+      replace: {
+        type: String,
+      },
+      targetref: {
+        type: String,
+      },
+      /**
+       * the URL to submit to
+       */
+      url: {
+        type: String,
+      },
+      validate: {
+        type: Boolean,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.model = this.parentNode;
+    // ### setting defaults...
+    this.method = 'GET';
+    this.nonrelevant = 'remove';
+    this.url = '';
+    this.replace = 'none';
+    this.targetref = '';
+    this.type = 'xml';
+    this.validate = true;
+  }
+
+  render() {
+    return html`
+      ${this.url
+        ? html`
+            <iron-ajax
+              id="submitter"
+              content-type="text/xml"
+              url="${this.url}"
+              method="${this.method}"
+              handle-as="text"
+              with-credentials
+              @error="${this._handleError}"
+              @response="${this._handleResponse}"
+            ></iron-ajax>
+          `
+        : ''}
+      <slot></slot>
+    `;
+  }
+
+  submit() {
+    // todo: call pre-hook once there is one ;)
+
+    // ### 1. update xpath context
+    this.evalInContext();
+
+    // ### 2. validate for submission
+    const model = this.getModel();
+    model.recalculate();
+
+    if (this.validate) {
+      model.revalidate();
     }
 
-    static get properties() {
-        return {
-            ...super.properties,
-            id:{
-                type: String
-            },
-            /**
-             * submission method - one of GET, POST, PUT, DELETE (HEAD?)
-             */
-            method:{
-                type:String
-            },
-            nonrelevant:{
-                type: String
-            },
-            /**
-             * what to do with the submission response. Either 'none' or 'instance' for now.
-             */
-            replace:{
-                type: String
-            },
-            targetref:{
-                type: String
-            },
-            /**
-             * the URL to submit to
-             */
-            url:{
-                type: String
-            },
-            validate:{
-                type: Boolean
-            }
-        };
+    // ### [3. select relevant nodes]
+    // ### [4. set request headers]
+    // ### 5. resolve URL
+    // ### 6. get serialized data if necessary
+    console.log('data ', this.nodeset);
+    // ### 7. trigger the submit execution
+
+    const submitter = this.shadowRoot.getElementById('submitter');
+    console.log('submitter ', submitter);
+
+    const serializer = new XMLSerializer();
+    const data = serializer.serializeToString(this.nodeset);
+    console.log('serialized data ', data);
+    submitter.body = data;
+    submitter.generateRequest();
+  }
+
+  _handleOnSubmit() {
+    // todo: implement submission pre-hook
+  }
+
+  _handleResponse() {
+    // ### check for 'replace' option
+    const submitter = this.shadowRoot.getElementById('submitter');
+    console.log('response ', submitter);
+    console.log('response ', submitter.lastResponse);
+    console.log('response ', submitter.lastError);
+
+    if (this.replace !== 'none') {
+      // ### 1. try to get instance with matching id
+      const targetInstance = this.model.getInstance(this.replace);
+      if (targetInstance) {
+        const instanceData = new DOMParser().parseFromString(submitter.lastResponse, 'text/xml');
+        targetInstance.instanceData = instanceData;
+        // targetInstance.instanceData = submitter.lastResponse;
+        console.log('replaced instance ', targetInstance.instanceData);
+        this.model.updateModel(); // force update
+        this.model.formElement.refresh();
+      }
+
+      // todo: evaluate expression in curly braces as xpath to resolve to the targetNode to replace
     }
 
-    constructor() {
-        super();
-        this.model = this.parentNode;
-        // ### setting defaults...
-        this.method = 'GET';
-        this.nonrelevant = 'remove';
-        this.url = '';
-        this.replace = 'none';
-        this.targetref = '';
-        this.type= 'xml';
-        this.validate = true;
-    }
+    this.dispatchEvent(
+      new CustomEvent('submit-done', {
+        composed: true,
+        bubbles: true,
+        detail: {},
+      }),
+    );
+  }
 
-    render() {
-        return html`
-            ${this.url?
-            html`
-                <iron-ajax 
-                    id="submitter"
-                    content-type="text/xml"
-                    url="${this.url}"
-                    method="${this.method}"
-                    handle-as="text"
-                    with-credentials
-                    @error="${this._handleError}"
-                    @response="${this._handleResponse}"
-                ></iron-ajax>
-            `:''}
-            <slot></slot>
-        `;
-    }
-
-    submit() {
-
-        //todo: call pre-hook once there is one ;)
-
-        // ### 1. update xpath context
-        this.evalInContext();
-
-        // ### 2. validate for submission
-        const model = this.getModel();
-        model.recalculate();
-
-        if(this.validate){
-            model.revalidate();
-        }
-
-        // ### [3. select relevant nodes]
-        // ### [4. set request headers]
-        // ### 5. resolve URL
-        // ### 6. get serialized data if necessary
-        console.log('data ', this.nodeset);
-        // ### 7. trigger the submit execution
-
-        const submitter = this.shadowRoot.getElementById('submitter');
-        console.log('submitter ', submitter);
-
-        const serializer = new XMLSerializer();
-        const data =  serializer.serializeToString(this.nodeset);
-        console.log('serialized data ', data);
-        submitter.body = data;
-        submitter.generateRequest();
-    }
-
-    _handleOnSubmit() {
-        //todo: implement submission pre-hook
-    }
-
-    _handleResponse(){
-        // ### check for 'replace' option
-        const submitter = this.shadowRoot.getElementById('submitter');
-        console.log('response ', submitter);
-        console.log('response ', submitter.lastResponse);
-        console.log('response ', submitter.lastError);
-
-        if( this.replace !== 'none') {
-
-            // ### 1. try to get instance with matching id
-            const targetInstance = this.model.getInstance(this.replace);
-            if(targetInstance){
-                const instanceData = new DOMParser().parseFromString(submitter.lastResponse,'text/xml');
-                targetInstance.instanceData = instanceData;
-                // targetInstance.instanceData = submitter.lastResponse;
-                console.log('replaced instance ', targetInstance.instanceData);
-                this.model.updateModel(); // force update
-                this.model.formElement.refresh();
-            }
-
-            // todo: evaluate expression in curly braces as xpath to resolve to the targetNode to replace
-
-        }
-
-
-        this.dispatchEvent(new CustomEvent('submit-done', {
-            composed: true,
-            bubbles: true,
-            detail: {}
-        }));
-
-
-    }
-
-    _handleError(){
-        console.log('ERRRORRRRR');
-        this.dispatchEvent(new CustomEvent('submit-error', {
-            composed: true,
-            bubbles: true,
-            detail: {}
-        }));
-
-    }
-
-
+  _handleError() {
+    console.log('ERRRORRRRR');
+    this.dispatchEvent(
+      new CustomEvent('submit-error', {
+        composed: true,
+        bubbles: true,
+        detail: {},
+      }),
+    );
+  }
 }
 customElements.define('fx-submission', FxSubmission);

--- a/src/modelitem.js
+++ b/src/modelitem.js
@@ -1,5 +1,3 @@
-
-
 /**
  * Class for holding ModelItem facets.
  *
@@ -8,75 +6,61 @@
  * Each bound node in an instance has exactly one ModelItem associated with it.
  */
 export class ModelItem {
+  /**
+   *
+   * @param {path} calculated normalized path expression linking to data
+   * @param {ref} ref relative binding expression
+   * @param {*} isReadonly - boolean to signal readonly/readwrite state
+   * @param {*} relevant - boolean to signal relevant/non-relevant state
+   * @param {*} required - boolean to signal required/optional state
+   * @param {*} required - boolean boolean to signal valid/invalid state
+   * @param {*} type - string expression to set a datatype
+   * @param {*} node - the node the 'ref' expression is referring to
+   * @param {*} bind - the fx-bind element having created this modelItem
+   */
+  constructor(path, ref, readonly, relevant, required, constraint, type, node, bind) {
+    this.path = path;
+    this.ref = ref;
+    this.constraint = constraint;
+    this.readonly = readonly;
+    this.relevant = relevant;
+    this.required = required;
+    this.type = type;
+    this.node = node;
+    this.bind = bind;
+    this.changed = false;
+    this.alerts = [];
+    // this.value = this._getValue();
+  }
 
-    /**
-     *
-     * @param {path} calculated normalized path expression linking to data
-     * @param {ref} ref relative binding expression
-     * @param {*} isReadonly - boolean to signal readonly/readwrite state
-     * @param {*} relevant - boolean to signal relevant/non-relevant state
-     * @param {*} required - boolean to signal required/optional state
-     * @param {*} required - boolean boolean to signal valid/invalid state
-     * @param {*} type - string expression to set a datatype
-     * @param {*} node - the node the 'ref' expression is referring to
-     * @param {*} bind - the fx-bind element having created this modelItem
-     */
-    constructor(
-                path,
-                ref,
-                readonly,
-                relevant,
-                required,
-                constraint,
-                type,
-                node,
-                bind) {
-        this.path = path;
-        this.ref = ref;
-        this.constraint = constraint;
-        this.readonly = readonly;
-        this.relevant = relevant;
-        this.required = required;
-        this.type = type;
-        this.node = node;
-        this.bind = bind;
-        this.changed = false;
-        this.alerts = [];
-        // this.value = this._getValue();
-    }
-
-/*
+  /*
     get ref(){
         return this.bind.ref;
     }
 */
 
-    get value(){
-        if(this.node.nodeType === Node.ATTRIBUTE_NODE){
-            return this.node.nodeValue;
-        }else{
-            return this.node.textContent;
-        }
+  get value() {
+    if (this.node.nodeType === Node.ATTRIBUTE_NODE) {
+      return this.node.nodeValue;
     }
+    return this.node.textContent;
+  }
 
-    set value(newVal) {
-        console.log('modelitem.setvalue oldVal', this.value);
-        console.log('modelitem.setvalue newVal', newVal);
-        if(this.node.nodeType === Node.ATTRIBUTE_NODE){
-            this.node.nodeValue = newVal;
-        }else{
-            this.node.textContent = newVal;
-        }
-
+  set value(newVal) {
+    console.log('modelitem.setvalue oldVal', this.value);
+    console.log('modelitem.setvalue newVal', newVal);
+    if (this.node.nodeType === Node.ATTRIBUTE_NODE) {
+      this.node.nodeValue = newVal;
+    } else {
+      this.node.textContent = newVal;
     }
+  }
 
-    addAlert(alert){
-        this.alerts.push(alert);
-    }
+  addAlert(alert) {
+    this.alerts.push(alert);
+  }
 
-    cleanAlerts(){
-        this.alerts = [];
-    }
-
+  cleanAlerts() {
+    this.alerts = [];
+  }
 }
-

--- a/src/ui/fx-abstract-control.js
+++ b/src/ui/fx-abstract-control.js
@@ -1,8 +1,8 @@
-import {LitElement, html, css} from 'lit-element';
+import { LitElement, html, css } from 'lit-element';
 
-import  '../fx-model.js';
-import {foreElementMixin} from "../ForeElementMixin.js";
-import { ModelItem } from "../modelitem.js";
+import '../fx-model.js';
+import { foreElementMixin } from '../ForeElementMixin.js';
+import { ModelItem } from '../modelitem.js';
 
 /**
  * `fx-abstract-control` -
@@ -12,206 +12,199 @@ import { ModelItem } from "../modelitem.js";
  * todo: remove LitElement dependency
  */
 export default class FxAbstractControl extends foreElementMixin(LitElement) {
+  static get properties() {
+    return {
+      ...super.properties,
+      value: {
+        type: String,
+      },
+      control: {
+        type: Object,
+      },
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties,
-            value:{
-                type: String
-            },
-            control:{
-                type:Object
-            }
-        };
-    }
+  constructor() {
+    super();
+    this.value = '';
+    this.display = this.style.display;
+  }
 
-    constructor(){
-        super();
-        this.value = "";
-        this.display = this.style.display;
-    }
+  /**
+   * (re)apply all state properties to this control.
+   */
+  async refresh() {
+    console.log('### FxAbstractControl.refresh on : ', this);
 
-    /**
-     * (re)apply all state properties to this control.
-     */
-    async refresh() {
-        console.log('### FxAbstractControl.refresh on : ', this);
+    const currentVal = this.value;
 
-        const currentVal = this.value;
+    // if(this.repeated) return ;
+    if (this.isNotBound()) return;
 
-        // if(this.repeated) return ;
-        if(this.isNotBound()) return;
+    await this.updateComplete;
+    this.evalInContext();
 
-        await this.updateComplete;
-        this.evalInContext();
+    if (this.isBound()) {
+      // this.control = this.querySelector('#control');
 
-        if(this.isBound()) {
-            // this.control = this.querySelector('#control');
+      if (this.nodeset === null) {
+        this.style.display = 'none';
+        return;
+      }
 
-            if (this.nodeset === null) {
-                this.style.display = 'none';
-                return;
-            }
+      this.modelItem = this.getModelItem();
 
-            this.modelItem = this.getModelItem();
+      if (this.modelItem instanceof ModelItem) {
+        // console.log('### XfAbstractControl.refresh modelItem : ', this.modelItem);
 
-            if (this.modelItem instanceof ModelItem) {
-                // console.log('### XfAbstractControl.refresh modelItem : ', this.modelItem);
-
-                this.value = this.modelItem.value;
-                // console.log('>>>>>>>> abstract refresh ', this.control);
-                // this.control[this.valueProp] = this.value;
-                await this.updateControlValue();
-
-
-                // if(!this.closest('fx-form').ready) return; // state change event do not fire during init phase (initial refresh)
-                // if(!this._getForm().ready) return; // state change event do not fire during init phase (initial refresh)
-                if (currentVal !== this.value) {
-                    this.dispatchEvent(new CustomEvent('value-changed', {}));
-                }
-                // this.requestUpdate();
-                this.handleModelItemProperties();
-            }
-        }
-        // await this.updateComplete;
-
-    }
-
-    async updateControlValue () {
+        this.value = this.modelItem.value;
+        // console.log('>>>>>>>> abstract refresh ', this.control);
         // this.control[this.valueProp] = this.value;
-        if(this.valueProp === 'checked'){
-            if(this.value === 'true'){
-                this.control.checked = true;
-            }else {
-                this.control.checked = false;
-            }
-        } else {
-            let control = this.control;
-            if(!control){
-                control = this;
-            }
-            control['value'] = this.value;
-            // control.value = this.value;
+        await this.updateControlValue();
+
+        // if(!this.closest('fx-form').ready) return; // state change event do not fire during init phase (initial refresh)
+        // if(!this._getForm().ready) return; // state change event do not fire during init phase (initial refresh)
+        if (currentVal !== this.value) {
+          this.dispatchEvent(new CustomEvent('value-changed', {}));
         }
+        // this.requestUpdate();
+        this.handleModelItemProperties();
+      }
+    }
+    // await this.updateComplete;
+  }
+
+  async updateControlValue() {
+    // this.control[this.valueProp] = this.value;
+    if (this.valueProp === 'checked') {
+      if (this.value === 'true') {
+        this.control.checked = true;
+      } else {
+        this.control.checked = false;
+      }
+    } else {
+      let { control } = this;
+      if (!control) {
+        control = this;
+      }
+      control.value = this.value;
+      // control.value = this.value;
+    }
+  }
+
+  get control() {
+    return this.getControl();
+  }
+
+  getControl() {
+    return this;
+  }
+
+  set control(control) {
+    this.control = control;
+  }
+
+  handleModelItemProperties() {
+    this.handleRequired();
+    this.handleReadonly();
+    this.handleValid();
+    this.handleRelevant();
+  }
+
+  _getForm() {
+    return this.getModel().parentNode;
+  }
+
+  handleRequired() {
+    // console.log('mip required', this.modelItem.required);
+    // const control = this.querySelector('#control');
+    if (this.isRequired() !== this.modelItem.required) {
+      if (this.modelItem.required) {
+        this.control.setAttribute('required', 'required');
+        // this.shadowRoot.getElementById('control').setAttribute('required','required');
+        // this.control.setAttribute('required','required');
+        // this.required = true;
+        // this.setAttribute('required','required');
+
+        this.classList.toggle('required');
+        this.dispatchEvent(new CustomEvent('required', {}));
+      } else {
+        this.control.removeAttribute('required');
+        this.required = false;
+        // this.removeAttribute('required');
+        this.classList.toggle('required');
+
+        this.dispatchEvent(new CustomEvent('optional', {}));
+      }
+    }
+  }
+
+  handleReadonly() {
+    // console.log('mip readonly', this.modelItem.isReadonly);
+    if (this.isReadonly() !== this.modelItem.readonly) {
+      if (this.modelItem.readonly) {
+        this.control.setAttribute('readonly', 'readonly');
+        // this.setAttribute('readonly','readonly');
+        this.classList.toggle('readonly');
+        this.dispatchEvent(new CustomEvent('readonly', {}));
+      }
+      if (!this.modelItem.readonly) {
+        this.control.removeAttribute('readonly');
+        // this.removeAttribute('readonly');
+        this.classList.toggle('readonly');
+
+        this.dispatchEvent(new CustomEvent('readwrite', {}));
+      }
+    }
+  }
+
+  handleValid() {
+    // console.log('mip valid', this.modelItem.required);
+
+    const alert = this.querySelector('fx-alert');
+    if (alert) {
+      alert.style.display = 'none';
     }
 
-    get control(){
-        return this.getControl();
-    }
-
-    getControl(){
-        return this;
-    }
-
-    set control(control){
-        this.control = control;
-    }
-
-    handleModelItemProperties(){
-        this.handleRequired();
-        this.handleReadonly();
-        this.handleValid();
-        this.handleRelevant();
-    }
-
-    _getForm(){
-        return this.getModel().parentNode;
-    }
-
-    handleRequired() {
-        // console.log('mip required', this.modelItem.required);
-        // const control = this.querySelector('#control');
-        if (this.isRequired() !== this.modelItem.required) {
-            if (this.modelItem.required) {
-                this.control.setAttribute('required','required');
-                // this.shadowRoot.getElementById('control').setAttribute('required','required');
-                // this.control.setAttribute('required','required');
-                // this.required = true;
-                // this.setAttribute('required','required');
-
-                this.classList.toggle('required');
-                this.dispatchEvent(new CustomEvent('required', {}));
-            } else {
-                this.control.removeAttribute('required');
-                this.required = false;
-                // this.removeAttribute('required');
-                this.classList.toggle('required');
-
-                this.dispatchEvent(new CustomEvent('optional', {}));
-            }
+    if (this.isValid() !== this.modelItem.valid) {
+      if (this.modelItem.valid) {
+        this.dispatchEvent(new CustomEvent('valid', {}));
+      } else {
+        if (this.modelItem.alerts.length !== 0) {
+          const alert = this.querySelector('fx-alert');
+          if (alert) {
+            alert.style.display = 'block';
+          } else {
+            const { alerts } = this.modelItem;
+            console.log('alerts from bind: ', alerts);
+            alerts.forEach(alert => {
+              const newAlert = document.createElement('fx-alert');
+              newAlert.innerHTML = alert;
+              this.appendChild(newAlert);
+              newAlert.style.display = 'block';
+            });
+          }
         }
+
+        this.dispatchEvent(new CustomEvent('invalid', {}));
+      }
     }
+  }
 
-    handleReadonly(){
-        // console.log('mip readonly', this.modelItem.isReadonly);
-        if (this.isReadonly() !== this.modelItem.readonly) {
-            if (this.modelItem.readonly) {
-                this.control.setAttribute('readonly','readonly');
-                // this.setAttribute('readonly','readonly');
-                this.classList.toggle('readonly');
-                this.dispatchEvent(new CustomEvent('readonly', {}));
-            }
-            if(!this.modelItem.readonly){
-                this.control.removeAttribute('readonly');
-                // this.removeAttribute('readonly');
-                this.classList.toggle('readonly');
-
-                this.dispatchEvent(new CustomEvent('readwrite', {}));
-            }
-        }
+  handleRelevant() {
+    // console.log('mip valid', this.modelItem.enabled);
+    if (this.isEnabled() !== this.modelItem.relevant) {
+      if (this.modelItem.relevant) {
+        this.dispatchEvent(new CustomEvent('relevant', {}));
+        this._fadeIn(this, this.display);
+      } else {
+        this.dispatchEvent(new CustomEvent('nonrelevant', {}));
+        this._fadeOut(this);
+      }
     }
+  }
 
-    handleValid(){
-        // console.log('mip valid', this.modelItem.required);
-
-
-        const alert = this.querySelector('fx-alert');
-        if(alert){
-            alert.style.display = "none";
-        }
-
-        if (this.isValid() !== this.modelItem.valid) {
-            if (this.modelItem.valid) {
-                this.dispatchEvent(new CustomEvent('valid', {}));
-            } else {
-                if(this.modelItem.alerts.length !== 0){
-
-                    const alert = this.querySelector('fx-alert');
-                    if(alert){
-                        alert.style.display = "block";
-                    }else{
-                        const alerts = this.modelItem.alerts;
-                        console.log('alerts from bind: ', alerts);
-                        alerts.forEach(alert => {
-                           const newAlert = document.createElement('fx-alert');
-                           newAlert.innerHTML = alert;
-                           this.appendChild(newAlert);
-                            newAlert.style.display = 'block';
-                        });
-                    }
-                }
-
-                this.dispatchEvent(new CustomEvent('invalid', {}));
-            }
-        }
-    }
-
-    handleRelevant(){
-        // console.log('mip valid', this.modelItem.enabled);
-        if (this.isEnabled() !== this.modelItem.relevant) {
-            if (this.modelItem.relevant) {
-                this.dispatchEvent(new CustomEvent('relevant', {}));
-                this._fadeIn(this, this.display);
-            } else {
-                this.dispatchEvent(new CustomEvent('nonrelevant', {}));
-                this._fadeOut(this);
-            }
-        }
-    }
-
-
-
-/*
+  /*
     setValue(node, newVal) {
 
         const m = this.getModelItem();
@@ -227,8 +220,7 @@ export default class FxAbstractControl extends foreElementMixin(LitElement) {
     }
 */
 
-
-/*
+  /*
     getValue() {
         // console.log('getValue nodeset ', this.nodeset);
         if (this.nodeset.nodeType === Node.ELEMENT_NODE) {
@@ -239,72 +231,70 @@ export default class FxAbstractControl extends foreElementMixin(LitElement) {
     }
 */
 
-    getControlValue(){};
+  getControlValue() {}
 
-
-    isRequired(){
-        // if(this.control.required){
-        // console.log('isRequired',this);
-        // this.control = this.shadowRoot.querySelector('#control');
-        if(!this.control){
-            this.control = this.shadowRoot.getElementById('control');
-        }
-        if(!this.control) return false;
-        if(this.control.hasAttribute('required')){
-            return true;
-        }
-        return false;
+  isRequired() {
+    // if(this.control.required){
+    // console.log('isRequired',this);
+    // this.control = this.shadowRoot.querySelector('#control');
+    if (!this.control) {
+      this.control = this.shadowRoot.getElementById('control');
     }
-
-    isValid(){
-        const control = this.getControl();
-        if(control.valid){
-            return true;
-        }
-        return false;
+    if (!this.control) return false;
+    if (this.control.hasAttribute('required')) {
+      return true;
     }
+    return false;
+  }
 
-    isReadonly(){
-        // const control = this.querySelector('#control');
-        if(this.control.hasAttribute('readonly')){
-            return true;
-        }
-        return false;
+  isValid() {
+    const control = this.getControl();
+    if (control.valid) {
+      return true;
     }
+    return false;
+  }
 
-    isEnabled(){
-        // if(this.style.display === 'none' || this.classList.contains('non-relevant')){
-        if(this.style.display === 'none'){
-            return false;
-        }
-        return true;
+  isReadonly() {
+    // const control = this.querySelector('#control');
+    if (this.control.hasAttribute('readonly')) {
+      return true;
     }
+    return false;
+  }
 
-    _fadeOut(el){
-        el.style.opacity = 1;
+  isEnabled() {
+    // if(this.style.display === 'none' || this.classList.contains('non-relevant')){
+    if (this.style.display === 'none') {
+      return false;
+    }
+    return true;
+  }
 
-        (function fade() {
-            if ((el.style.opacity -= .1) < 0) {
-                el.style.display = "none";
-            } else {
-                requestAnimationFrame(fade);
-            }
-        })();
-    };
+  _fadeOut(el) {
+    el.style.opacity = 1;
 
-    _fadeIn(el, display){
-        el.style.opacity = 0;
-        el.style.display = display || "block";
+    (function fade() {
+      if ((el.style.opacity -= 0.1) < 0) {
+        el.style.display = 'none';
+      } else {
+        requestAnimationFrame(fade);
+      }
+    })();
+  }
 
-        (function fade() {
-            var val = parseFloat(el.style.opacity);
-            if (!((val += .1) > 1)) {
-                el.style.opacity = val;
-                requestAnimationFrame(fade);
-            }
-        })();
-    };
+  _fadeIn(el, display) {
+    el.style.opacity = 0;
+    el.style.display = display || 'block';
 
+    (function fade() {
+      let val = parseFloat(el.style.opacity);
+      if (!((val += 0.1) > 1)) {
+        el.style.opacity = val;
+        requestAnimationFrame(fade);
+      }
+    })();
+  }
 }
 
 window.customElements.define('fx-abstract-control', FxAbstractControl);

--- a/src/ui/fx-alert.js
+++ b/src/ui/fx-alert.js
@@ -1,55 +1,50 @@
-import { html, css} from 'lit-element';
+import { html, css } from 'lit-element';
 
 import XfAbstractControl from './fx-abstract-control.js';
 
 export class FxAlert extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        height: auto;
+        font-size: 0.8em;
+        font-weight: 400;
+        color: red;
+        display: none;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-            :host {
-                display: block;
-                height:auto;
-                font-size:0.8em;
-                font-weight:400;
-                color:red;
-                display:none;
-            }
-        `;
-    }
+  constructor() {
+    super();
+    this.style.display = 'none';
+  }
 
-    constructor() {
-        super();
-        this.style.display = 'none';
-    }
+  static get properties() {
+    return {
+      ...super.properties,
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties
-        };
-    }
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
 
+  isRequired() {
+    return false;
+  }
 
-    render() {
-        return html`
-            <slot></slot>
-        `;
-    }
+  isReadonly() {
+    return true;
+  }
 
-    isRequired () {
-        return false;
-    }
+  handleRequired(mi) {}
 
-    isReadonly (){
-        return true;
-    }
-
-    handleRequired(mi) {
-    }
-
-    handleReadonly() {
-        // super.handleReadonly();
-    }
-
-
+  handleReadonly() {
+    // super.handleReadonly();
+  }
 }
 customElements.define('fx-alert', FxAlert);

--- a/src/ui/fx-button.js
+++ b/src/ui/fx-button.js
@@ -1,6 +1,6 @@
-import {LitElement, html, css} from 'lit-element';
+import { LitElement, html, css } from 'lit-element';
 import '@polymer/paper-button/paper-button.js';
-import XfAbstractControl from "./fx-abstract-control.js";
+import XfAbstractControl from './fx-abstract-control.js';
 /**
  * `fx-button`
  * a button triggering Fore actions
@@ -9,94 +9,83 @@ import XfAbstractControl from "./fx-abstract-control.js";
  * @demo demo/index.html
  */
 class FxButton extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+      paper-button {
+        height: inherit;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-        :host {
-          display: inline-block;
-        }
-        paper-button{
-            height:inherit;
-        }
-        `;
+  static get properties() {
+    return {
+      ...super.properties,
+      label: {
+        type: String,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.label = '';
+  }
+
+  render() {
+    return html`
+      <paper-button id="control" @click="${this.performActions}" raised>${this.label}</paper-button>
+      <slot></slot>
+    `;
+  }
+
+  performActions() {
+    console.log('performActions ', this.children);
+
+    const repeatedItem = this.closest('fx-repeatitem');
+    if (repeatedItem) {
+      console.log('repeated click');
+      repeatedItem.click();
+    }
+    for (let i = 0; i < this.children.length; i++) {
+      // console.log('child ', this.children[i]);
+      const child = this.children[i];
+
+      if (typeof child.execute === 'function') {
+        child.execute();
+      } else {
+        console.warn('child has no "execute" function ', child);
+        return false;
+      }
     }
 
-    static get properties() {
-        return {
-            ...super.properties,
-            label:{
-                type: String
-            }
-        };
-    }
+    // ### signal to form that action-block is complete and changes should be send
+    this.dispatchEvent(
+      new CustomEvent('actions-performed', {
+        composed: true,
+        bubbles: true,
+        detail: {},
+      }),
+    );
 
-    constructor(){
-        super();
-        this.label = '';
-    }
+    return true;
+  }
 
-    render() {
-        return html`
-           <paper-button id="control" @click="${this.performActions}" raised>${this.label}</paper-button>
-           <slot></slot>         
-        `;
-    }
+  refresh() {
+    // super.refresh();
+    // console.log('fx-button refresh');
 
-    performActions() {
-        console.log('performActions ', this.children);
+    const elements = this.querySelectorAll(':scope > *');
+    elements.forEach(element => {
+      if (typeof element.refresh === 'function') {
+        element.refresh();
+      }
+    });
+  }
 
-        const repeatedItem = this.closest('fx-repeatitem');
-        if(repeatedItem){
-            console.log('repeated click');
-            repeatedItem.click();
-        }
-        for (let i = 0; i < this.children.length; i++) {
-            // console.log('child ', this.children[i]);
-            const child = this.children[i];
-
-            if(typeof child.execute === 'function' ){
-                child.execute();
-            }else{
-                console.warn('child has no "execute" function ', child);
-                return false;
-            }
-        }
-
-        // ### signal to form that action-block is complete and changes should be send
-        this.dispatchEvent(new CustomEvent(
-            'actions-performed',
-            {
-                composed: true,
-                bubbles: true,
-                detail: {}
-            }));
-
-        return true;
-
-    }
-
-    refresh(){
-        // super.refresh();
-        // console.log('fx-button refresh');
-
-        const elements = this.querySelectorAll(':scope > *');
-        elements.forEach(element => {
-
-            if (typeof element.refresh === 'function') {
-                element.refresh();
-            }
-
-        });
-
-
-
-
-    }
-
-    handleRequired () {
-    }
-
-
+  handleRequired() {}
 }
 
 window.customElements.define('fx-button', FxButton);

--- a/src/ui/fx-case.js
+++ b/src/ui/fx-case.js
@@ -1,6 +1,5 @@
-import {Fore} from "../fore";
-import {foreElementMixin} from "../ForeElementMixin";
-
+import { Fore } from '../fore';
+import { foreElementMixin } from '../ForeElementMixin';
 
 /**
  * `fx-case`
@@ -9,43 +8,38 @@ import {foreElementMixin} from "../ForeElementMixin";
  *  * todo: implement
  * @customElement
  */
-class FxCase extends HTMLElement{
+class FxCase extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
 
-
-    constructor(){
-        super();
-        this.attachShadow({mode:'open'});
+  connectedCallback() {
+    if (this.hasAttribute('label')) {
+      this.label = this.getAttribute('label');
+    }
+    if (this.hasAttribute('name')) {
+      this.name = this.getAttribute('name');
+    }
+    if (this.hasAttribute('selected')) {
+      this.selected = this.getAttribute('selected');
     }
 
-    connectedCallback(){
-        if(this.hasAttribute('label')){
-            this.label=this.getAttribute('label');
-        }
-        if(this.hasAttribute('name')){
-            this.name=this.getAttribute('name');
-        }
-        if(this.hasAttribute('selected')){
-            this.selected=this.getAttribute('selected');
-        }
-
-        const style = `
+    const style = `
             :host {
                 display: block;
             }
         `;
-        const html = `
+    const html = `
            <slot></slot>
         `;
-        this.shadowRoot.innerHTML = `
+    this.shadowRoot.innerHTML = `
             <style>
                 ${style}
             </style>
             ${html}
         `;
-
-    }
-
-
+  }
 }
 
 window.customElements.define('fx-case', FxCase);

--- a/src/ui/fx-container.js
+++ b/src/ui/fx-container.js
@@ -1,8 +1,8 @@
-import {LitElement, html, css} from 'lit-element';
+import { LitElement, html, css } from 'lit-element';
 
-import  '../fx-model.js';
-import {Fore} from "../fore.js";
-import {foreElementMixin} from "../ForeElementMixin.js";
+import '../fx-model.js';
+import { Fore } from '../fore.js';
+import { foreElementMixin } from '../ForeElementMixin.js';
 
 /**
  * `fx-container` -
@@ -13,8 +13,7 @@ import {foreElementMixin} from "../ForeElementMixin.js";
 // export class FxContainer extends BoundElement {
 // export class FxContainer extends foreElementMixin(LitElement) {
 export class FxContainer extends foreElementMixin(LitElement) {
-
-/*
+  /*
     static get properties() {
         return {
             ...super.properties,
@@ -22,7 +21,7 @@ export class FxContainer extends foreElementMixin(LitElement) {
     }
 
 */
-/*
+  /*
     render() {
         return html`
             <slot></slot>
@@ -30,97 +29,87 @@ export class FxContainer extends foreElementMixin(LitElement) {
     }
 */
 
+  constructor() {
+    super();
+  }
 
-    constructor(){
-        super();
-    }
-
-/*
+  /*
     firstUpdated(_changedProperties) {
         // console.log('firstUpdated ', this);
         this.control = this.shadowRoot.querySelector('#control');
     }
 */
 
+  /**
+   * (re)apply all state properties to this control.
+   */
+  refresh() {
+    console.log('### FxContainer.refresh on : ', this);
 
-
-    /**
-     * (re)apply all state properties to this control.
-     */
-    refresh() {
-        console.log('### FxContainer.refresh on : ', this);
-
-        if(this.isBound()){
-            this.evalInContext();
-            this.modelItem = this.getModelItem();
-            this.value = this.modelItem.value;
-        }
-
-        // await this.updateComplete;
-
-        // state change event do not fire during init phase (initial refresh)
-        if(this._getForm().ready) {
-            this.handleModelItemProperties();
-        }
-        // this.requestUpdate();
-
-        Fore.refreshChildren(this);
+    if (this.isBound()) {
+      this.evalInContext();
+      this.modelItem = this.getModelItem();
+      this.value = this.modelItem.value;
     }
 
-    handleModelItemProperties(){
-        this.handleReadonly();
-        this.handleRelevant();
+    // await this.updateComplete;
+
+    // state change event do not fire during init phase (initial refresh)
+    if (this._getForm().ready) {
+      this.handleModelItemProperties();
     }
+    // this.requestUpdate();
 
-    _getForm(){
-        return this.getModel().parentNode;
+    Fore.refreshChildren(this);
+  }
+
+  handleModelItemProperties() {
+    this.handleReadonly();
+    this.handleRelevant();
+  }
+
+  _getForm() {
+    return this.getModel().parentNode;
+  }
+
+  handleReadonly() {
+    // console.log('mip readonly', this.modelItem.isReadonly);
+    if (this.isReadonly() !== this.modelItem.readonly) {
+      if (this.modelItem.readonly) {
+        this.setAttribute('readonly', 'readonly');
+        this.dispatchEvent(new CustomEvent('readonly', {}));
+      }
+      if (!this.modelItem.readonly) {
+        this.removeAttribute('readonly');
+        this.dispatchEvent(new CustomEvent('readwrite', {}));
+      }
     }
+  }
 
-
-    handleReadonly(){
-        // console.log('mip readonly', this.modelItem.isReadonly);
-        if (this.isReadonly() !== this.modelItem.readonly) {
-            if (this.modelItem.readonly) {
-                this.setAttribute('readonly','readonly');
-                this.dispatchEvent(new CustomEvent('readonly', {}));
-            }
-            if(!this.modelItem.readonly){
-                this.removeAttribute('readonly');
-                this.dispatchEvent(new CustomEvent('readwrite', {}));
-            }
-        }
+  handleRelevant() {
+    // console.log('mip valid', this.modelItem.enabled);
+    if (this.isEnabled() !== this.modelItem.enabled) {
+      if (this.modelItem.enabled) {
+        this.dispatchEvent(new CustomEvent('enabled', {}));
+      } else {
+        this.dispatchEvent(new CustomEvent('disabled', {}));
+      }
     }
+  }
 
-
-    handleRelevant(){
-        // console.log('mip valid', this.modelItem.enabled);
-        if (this.isEnabled() !== this.modelItem.enabled) {
-            if (this.modelItem.enabled) {
-                this.dispatchEvent(new CustomEvent('enabled', {}));
-            } else {
-                this.dispatchEvent(new CustomEvent('disabled', {}));
-            }
-        }
+  isReadonly() {
+    if (this.hasAttribute('readonly')) {
+      return true;
     }
+    return false;
+  }
 
-
-
-    isReadonly(){
-        if(this.hasAttribute('readonly')){
-            return true;
-        }
-        return false;
+  isEnabled() {
+    if (this.style.display === 'none') {
+      return false;
     }
-
-    isEnabled(){
-        if(this.style.display === 'none'){
-            return false;
-        }
-        return true;
-    }
-
-
-
+    return true;
+  }
 }
 
 window.customElements.define('fx-container', FxContainer);

--- a/src/ui/fx-control.js
+++ b/src/ui/fx-control.js
@@ -1,7 +1,7 @@
-import {css, html} from 'lit-element';
-import XfAbstractControl from "./fx-abstract-control.js";
-import {Fore} from "../fore.js";
-import {evaluateXPathToNodes} from '../xpath-evaluation.js';
+import { css, html } from 'lit-element';
+import XfAbstractControl from './fx-abstract-control.js';
+import { Fore } from '../fore.js';
+import { evaluateXPathToNodes } from '../xpath-evaluation.js';
 
 /**
  * `fx-control`
@@ -13,149 +13,143 @@ import {evaluateXPathToNodes} from '../xpath-evaluation.js';
  * @demo demo/index.html
  */
 class FxControl extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+      :host([required]) span::after {
+        content: '*';
+        color: var(--paper-red-500);
+        padding-left: 5px;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-        :host {
-          display: inline-block;
+  static get properties() {
+    return {
+      ...super.properties,
+      updateEvent: {
+        type: String,
+        attribute: 'update-event',
+      },
+      valueProp: {
+        type: String,
+        attribute: 'value-prop',
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.updateEvent = 'blur';
+    this.valueProp = 'value'; // default
+    this.inited = false;
+  }
+
+  render() {
+    return html`
+      <slot name="alert"></slot>
+      <slot name="label"></slot>
+      <slot></slot>
+      <slot name="hint"></slot>
+      <fx-setvalue id="setvalue" ref="${this.ref}"></fx-setvalue>
+    `;
+  }
+
+  firstUpdated(_changedProperties) {
+    console.log('firstUpdated ', _changedProperties);
+    super.firstUpdated(_changedProperties);
+    // console.log('updateEvent', this.updateEvent);
+
+    let { control } = this;
+    if (!control) {
+      const input = document.createElement('input');
+      input.setAttribute('type', 'text');
+      this.appendChild(input);
+      control = input;
+    }
+
+    control.addEventListener(this.updateEvent, e => {
+      console.log('eventlistener ', this.updateEvent);
+
+      const modelitem = this.getModelItem();
+      const setval = this.shadowRoot.getElementById('setvalue');
+      setval.setValue(modelitem, control[this.valueProp]);
+      // console.log('updated modelitem ', modelitem);
+    });
+
+    this.inited = true;
+  }
+
+  get control() {
+    const defaultSlot = this.shadowRoot.querySelector('slot:not([name])');
+    const ctrl = defaultSlot.assignedElements({ flatten: true })[0];
+    return ctrl;
+  }
+
+  async refresh() {
+    super.refresh();
+    await this.updateComplete;
+    const { control } = this;
+
+    // ### if we find a ref on control we have a 'select' control of some kind
+    // todo: review - seems a bit implicite to draw that 'itemset decision' just from the existence of a 'ref'
+    if (this.control.hasAttribute('ref')) {
+      const tmpl = control.querySelector('template');
+
+      // ### eval nodeset for list control
+      const ref = control.getAttribute('ref');
+      const inscope = this._inScopeContext();
+      const formElement = this.closest('fx-form');
+      const nodeset = evaluateXPathToNodes(ref, inscope, formElement, Fore.namespaceResolver);
+
+      // ### clear items
+      const { children } = this.control;
+      Array.from(children).forEach(child => {
+        if (child.nodeName.toLowerCase() !== 'template') {
+          child.parentNode.removeChild(child);
         }
-        :host([required]) span::after {
-            content:'*';
-            color:var(--paper-red-500);
-            padding-left:5px;
-        }
+      });
 
-        `;
+      // ### build the items
+      Array.from(nodeset).forEach(node => {
+        const content = tmpl.content.firstElementChild.cloneNode(true);
+        const newEntry = document.importNode(content, true);
+        // console.log('newEntry ', newEntry);
+        this.control.appendChild(newEntry);
+
+        // ### initialize new entry
+        // ### set value
+        const valueAttribute = this._getValueAttribute(newEntry);
+        const valueExpr = valueAttribute.value;
+        const cutted = valueExpr.substring(1, valueExpr.length - 1);
+        const evaluated = Fore.evaluateXPath(cutted, node, formElement, Fore.namespaceResolver);
+        valueAttribute.value = evaluated;
+
+        // ### set label
+        const optionLabel = newEntry.textContent;
+        const labelExpr = optionLabel.substring(1, optionLabel.length - 1);
+        console.log('label Expr ', labelExpr);
+
+        // todo : should use evaluateToString()
+        const label = Fore.evaluateXPath(labelExpr, node, formElement, Fore.namespaceResolver);
+        newEntry.textContent = label.textContent;
+      });
     }
+  }
 
-    static get properties() {
-        return {
-            ...super.properties,
-            updateEvent:{
-                type: String,
-                attribute:'update-event'
-            },
-            valueProp:{
-                type:String,
-                attribute:'value-prop'
-            }
-        };
-    }
-
-    constructor(){
-        super();
-        this.updateEvent='blur';
-        this.valueProp='value'; // default
-        this.inited = false;
-    }
-
-    render() {
-        return html`
-           <slot name="alert"></slot>
-           <slot name="label"></slot>
-           <slot></slot>
-           <slot name="hint"></slot>
-           <fx-setvalue id="setvalue" ref="${this.ref}"></fx-setvalue>
-        `;
-    }
-
-    firstUpdated(_changedProperties) {
-        console.log('firstUpdated ', _changedProperties);
-        super.firstUpdated(_changedProperties);
-        // console.log('updateEvent', this.updateEvent);
-
-        let {control} = this;
-        if(!control){
-            const input = document.createElement('input');
-            input.setAttribute('type', 'text');
-            this.appendChild(input);
-            control = input;
-        }
-
-        control.addEventListener(this.updateEvent, (e) => {
-            console.log('eventlistener ', this.updateEvent);
-
-            const modelitem = this.getModelItem();
-            const setval = this.shadowRoot.getElementById('setvalue');
-            setval.setValue(modelitem, control[this.valueProp]);
-            // console.log('updated modelitem ', modelitem);
-        });
-
-        this.inited = true;
-    }
-
-    get control(){
-        const defaultSlot = this.shadowRoot.querySelector('slot:not([name])');
-        const ctrl = defaultSlot.assignedElements({flatten: true})[0];
-        return  ctrl;
-    }
-
-    async refresh () {
-        super.refresh();
-        await this.updateComplete;
-        const {control} = this;
-
-        // ### if we find a ref on control we have a 'select' control of some kind
-        // todo: review - seems a bit implicite to draw that 'itemset decision' just from the existence of a 'ref'
-        if(this.control.hasAttribute('ref')){
-            const tmpl = control.querySelector('template');
-
-            // ### eval nodeset for list control
-            const ref = control.getAttribute('ref');
-            const inscope = this._inScopeContext();
-            const formElement = this.closest('fx-form');
-            const nodeset = evaluateXPathToNodes (ref, inscope, formElement, Fore.namespaceResolver) ;
-
-            // ### clear items
-            const {children} = this.control;
-            Array.from(children).forEach(child => {
-               if(child.nodeName.toLowerCase() !== 'template'){
-                   child.parentNode.removeChild(child);
-               }
-            });
-
-            // ### build the items
-            Array.from(nodeset).forEach(node => {
-                const content = tmpl.content.firstElementChild.cloneNode(true);
-                const newEntry = document.importNode(content, true);
-                // console.log('newEntry ', newEntry);
-                this.control.appendChild(newEntry);
-
-                // ### initialize new entry
-                // ### set value
-                const valueAttribute = this._getValueAttribute(newEntry);
-                const valueExpr = valueAttribute.value;
-                const cutted = valueExpr.substring(1, valueExpr.length -1);
-                const evaluated = Fore.evaluateXPath(cutted, node, formElement, Fore.namespaceResolver) ;
-                valueAttribute.value = evaluated;
-
-                // ### set label
-                const optionLabel = newEntry.textContent;
-                const labelExpr = optionLabel.substring(1, optionLabel.length-1);
-                console.log('label Expr ', labelExpr);
-
-                // todo : should use evaluateToString()
-                const label = Fore.evaluateXPath(labelExpr, node, formElement, Fore.namespaceResolver) ;
-                newEntry.textContent = label.textContent;
-
-            });
-        }
-
-    }
-
-    _getValueAttribute (element){
-        let result;
-        Array.from(element.attributes).forEach(attribute => {
-            const attrVal = attribute.value;
-            if(attrVal.indexOf('{') !== -1){
-                // console.log('avt found ', attribute);
-                result =  attribute;
-            }
-
-        });
-        return result;
-    }
-
+  _getValueAttribute(element) {
+    let result;
+    Array.from(element.attributes).forEach(attribute => {
+      const attrVal = attribute.value;
+      if (attrVal.indexOf('{') !== -1) {
+        // console.log('avt found ', attribute);
+        result = attribute;
+      }
+    });
+    return result;
+  }
 }
 
 window.customElements.define('fx-control', FxControl);

--- a/src/ui/fx-group.js
+++ b/src/ui/fx-group.js
@@ -1,8 +1,7 @@
-import {LitElement, html, css} from 'lit-element';
-import {Fore} from "../fore";
+import { LitElement, html, css } from 'lit-element';
+import { Fore } from '../fore';
 // import XfAbstractControl from "./fx-abstract-control";
-import {FxContainer} from './fx-container';
-
+import { FxContainer } from './fx-container';
 
 /**
  * `fx-group`
@@ -12,19 +11,17 @@ import {FxContainer} from './fx-container';
  *  * todo: implement
  * @customElement
  */
-class FxGroup extends FxContainer{
-
-
-    static get properties() {
-        return{
-            ... super.properties,
-            collapse:{
-                type:Boolean,
-                reflect:true
-            }
-        }
-    }
-        /*
+class FxGroup extends FxContainer {
+  static get properties() {
+    return {
+      ...super.properties,
+      collapse: {
+        type: Boolean,
+        reflect: true,
+      },
+    };
+  }
+  /*
             init(model){
                 super.init(model);
                 console.log(this, this.modelItem);
@@ -33,46 +30,45 @@ class FxGroup extends FxContainer{
             }
         */
 
-    constructor(){
-        super();
-        this.collapse = false;
-    }
+  constructor() {
+    super();
+    this.collapse = false;
+  }
 
-    render() {
-        return html`
-            <div>
-                <slot></slot>
-            </div>
-        `;
-    }
+  render() {
+    return html`
+      <div>
+        <slot></slot>
+      </div>
+    `;
+  }
 
-    /**
-     * overwrites Abstract Control.
-     *
-     * Groups only reacts to 'relevant' property.
-     */
-    handleModelItemProperties(){
-        this.handleRelevant();
-    }
+  /**
+   * overwrites Abstract Control.
+   *
+   * Groups only reacts to 'relevant' property.
+   */
+  handleModelItemProperties() {
+    this.handleRelevant();
+  }
 
-    initializeChildren(node){
-        const children = Array.from(node.children);
-        console.log('_initializeChildren ', children);
+  initializeChildren(node) {
+    const children = Array.from(node.children);
+    console.log('_initializeChildren ', children);
 
-        children.forEach(child => {
-            console.log('child ', child);
+    children.forEach(child => {
+      console.log('child ', child);
 
-            if(Fore.isUiElement(child.nodeName)){
-                child.init(this.model);
-            }else if(child.children.length !== 0){
-                const grantChildren = Array.from(child.children);
-                grantChildren.forEach(grantChild =>{
-                    this.initializeChildren(grantChild);
-                });
-            }
-
+      if (Fore.isUiElement(child.nodeName)) {
+        child.init(this.model);
+      } else if (child.children.length !== 0) {
+        const grantChildren = Array.from(child.children);
+        grantChildren.forEach(grantChild => {
+          this.initializeChildren(grantChild);
         });
-        /*
+      }
+    });
+    /*
                 if(Fore.isUiElement(node.nodeName)){
                     const childElements = children.filter( action => Fore.isUiElement(action.nodeName));
                     console.log('children ', childElements);
@@ -88,11 +84,8 @@ class FxGroup extends FxContainer{
                 }
         */
 
-
-        console.groupEnd();
-    }
-
-
+    console.groupEnd();
+  }
 }
 
 window.customElements.define('fx-group', FxGroup);

--- a/src/ui/fx-hint.js
+++ b/src/ui/fx-hint.js
@@ -1,49 +1,44 @@
-import { html, css} from 'lit-element';
+import { html, css } from 'lit-element';
 
 import XfAbstractControl from './fx-abstract-control.js';
 
 export class FxHint extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        height: auto;
+        font-size: 0.8em;
+        font-weight: 400;
+        font-style: italic;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-            :host {
-                display: block;
-                height:auto;
-                font-size:0.8em;
-                font-weight:400;
-                font-style:italic;
-            }
-        `;
-    }
+  static get properties() {
+    return {
+      ...super.properties,
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties
-        };
-    }
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
 
+  isRequired() {
+    return false;
+  }
 
-    render() {
-        return html`
-            <slot></slot>
-        `;
-    }
+  isReadonly() {
+    return true;
+  }
 
-    isRequired () {
-        return false;
-    }
+  handleRequired(mi) {}
 
-    isReadonly (){
-        return true;
-    }
-
-    handleRequired(mi) {
-    }
-
-    handleReadonly() {
-        // super.handleReadonly();
-    }
-
-
+  handleReadonly() {
+    // super.handleReadonly();
+  }
 }
 customElements.define('fx-hint', FxHint);

--- a/src/ui/fx-input.js
+++ b/src/ui/fx-input.js
@@ -1,9 +1,9 @@
-import {html,css} from "lit-element";
+import { html, css } from 'lit-element';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/paper-checkbox/paper-checkbox.js';
-import XfAbstractControl from "./fx-abstract-control.js";
-import "../actions/fx-setvalue.js";
-import "../fx-model.js";
+import XfAbstractControl from './fx-abstract-control.js';
+import '../actions/fx-setvalue.js';
+import '../fx-model.js';
 
 /**
  * `fx-input`
@@ -11,103 +11,106 @@ import "../fx-model.js";
  *
  * @customElement
  */
-class FxInput extends XfAbstractControl{
+class FxInput extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+      paper-input {
+        display: inline-block;
+      }
+      label {
+        display: block;
+      }
+      .alert {
+        color: ;
+      }
+    `;
+  }
 
+  static get properties() {
+    return {
+      ...super.properties,
+      type: {
+        type: String,
+      },
+      label: {
+        type: String,
+      },
+      value: {
+        type: String,
+        attribute: 'value',
+        reflect: true,
+      },
+      required: {
+        type: Boolean,
+        reflect: true,
+      },
+    };
+  }
 
-    static get styles() {
-        return css`
-        :host {
-          display: inline-block;
-        }
-        paper-input{
-            display:inline-block;
-        }
-        label{
-            display:block;
-        }
-        .alert{
-            color:
-        }
-        `;
-    }
+  constructor() {
+    super();
+    this.type = 'text';
+    this.label = '';
+    this.value = '';
+    this.required = false;
+    this.valid = true;
+  }
 
-    static get properties() {
-        return {
-            ... super.properties,
-            type:{
-                type: String
-            },
-            label:{
-                type: String
-            },
-            value:{
-                type: String,
-                attribute:'value',
-                reflect:true
-            },
-            required:{
-                type:Boolean,
-                reflect:true
-            }
+  render() {
+    return html`
+      ${this.type === 'text' || this.type === 'date'
+        ? html`
+            <slot></slot>
+            <paper-input
+              id="control"
+              label="${this.label}"
+              .value="${this.value}"
+              type="${this.type}"
+              ?required="${this.required}"
+              ?this.readonly="${this.readonly}"
+              @input="${this._handleInput}"
+            >
+            </paper-input>
+            <fx-setvalue id="setvalue" ref="${this.ref}" value="${this.value}"></fx-setvalue>
+          `
+        : ''}
+      ${this.type === 'checkbox'
+        ? html`
+            <paper-checkbox
+              id="control"
+              label="${this.label}"
+              ?checked="${this.value === 'true'}"
+            ></paper-checkbox>
+          `
+        : ''}
+    `;
+  }
 
-        };
-    }
+  _handleInput(e) {
+    // const mi = this.getmdelItem();
+    console.log('_handleInput ', this.modelItem);
+    // console.log('modelItem ', mi);
 
-    constructor(){
-        super();
-        this.type = 'text';
-        this.label='';
-        this.value='';
-        this.required = false;
-        this.valid = true;
-    }
+    const inputValue = this.shadowRoot.querySelector('#control').value;
 
+    const setval = this.shadowRoot.querySelector('#setvalue');
+    setval.model = this.getModel();
+    setval.setValue(this.modelItem, inputValue);
 
-    render() {
-        return html`
-            ${this.type === 'text' || this.type === 'date' ?
-                html`
-                    <slot></slot>
-                    <paper-input id="control" 
-                                  label="${this.label}"
-                                  .value="${this.value}"
-                                  type="${this.type}"
-                                  ?required="${this.required}"
-                                  ?this.readonly="${this.readonly}"
-                                  @input="${this._handleInput}">
-                    </paper-input>
-                    <fx-setvalue id="setvalue" ref="${this.ref}" value="${this.value}"></fx-setvalue>
-                    ` :''}
-            
-            ${this.type === 'checkbox' ?
-                html`<paper-checkbox id="control" label="${this.label}" ?checked="${this.value === 'true'}"></paper-checkbox>` :''}
-        `;
-    }
+    console.log('instanceData ', this.getModel().instances[0].getInstanceData());
+  }
 
-    _handleInput(e) {
-        // const mi = this.getmdelItem();
-        console.log('_handleInput ', this.modelItem);
-        // console.log('modelItem ', mi);
+  getControl() {
+    return this.shadowRoot.getElementById('control');
+  }
 
-        const inputValue = this.shadowRoot.querySelector('#control').value;
-
-        const setval = this.shadowRoot.querySelector('#setvalue');
-        setval.model = this.getModel();
-        setval.setValue(this.modelItem, inputValue);
-
-        console.log('instanceData ', this.getModel().instances[0].getInstanceData());
-
-    }
-
-    getControl(){
-        return this.shadowRoot.getElementById('control');
-    }
-
-    // updateControlValue(){
-    //     console.log('_updateControlValue fx-input');
-    //     this.shadowRoot.getElementById('control').value = this.value;
-    // }
-
+  // updateControlValue(){
+  //     console.log('_updateControlValue fx-input');
+  //     this.shadowRoot.getElementById('control').value = this.value;
+  // }
 }
 
 window.customElements.define('fx-input', FxInput);

--- a/src/ui/fx-items.js
+++ b/src/ui/fx-items.js
@@ -1,4 +1,4 @@
-import { html, css} from 'lit-element';
+import { html, css } from 'lit-element';
 
 import XfAbstractControl from './fx-abstract-control.js';
 
@@ -6,47 +6,42 @@ import XfAbstractControl from './fx-abstract-control.js';
  * todo
  */
 export class FxItems extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        height: auto;
+        font-size: 0.8em;
+        font-weight: 400;
+        font-style: italic;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-            :host {
-                display: block;
-                height:auto;
-                font-size:0.8em;
-                font-weight:400;
-                font-style:italic;
-            }
-        `;
-    }
+  static get properties() {
+    return {
+      ...super.properties,
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties
-        };
-    }
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
 
+  isRequired() {
+    return false;
+  }
 
-    render() {
-        return html`
-            <slot></slot>
-        `;
-    }
+  isReadonly() {
+    return true;
+  }
 
-    isRequired () {
-        return false;
-    }
+  handleRequired(mi) {}
 
-    isReadonly (){
-        return true;
-    }
-
-    handleRequired(mi) {
-    }
-
-    handleReadonly() {
-        // super.handleReadonly();
-    }
-
-
+  handleReadonly() {
+    // super.handleReadonly();
+  }
 }
 customElements.define('fx-items', FxItems);

--- a/src/ui/fx-output.js
+++ b/src/ui/fx-output.js
@@ -1,47 +1,45 @@
-import { html, css} from 'lit-element';
+import { html, css } from 'lit-element';
 
 import XfAbstractControl from './fx-abstract-control.js';
 
 export class FxOutput extends XfAbstractControl {
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+      #control {
+        display: inline-block;
+      }
+      [name='label'] {
+        display: inline;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-            :host {
-                display: inline-block;
-            }
-            #control{
-                display:inline-block;
-            }
-            [name='label']{
-                display:inline;
-            }
-        `;
-    }
+  static get properties() {
+    return {
+      ...super.properties,
+    };
+  }
 
-    static get properties() {
-        return {
-            ...super.properties
-        };
-    }
+  render() {
+    return html`
+      <slot name="label"></slot>
+      <span id="control">${this.value}</span>
+    `;
+  }
 
-
-    render() {
-        return html`
-            <slot name="label"></slot>
-            <span id="control">${this.value}</span>
-        `;
-    }
-
-    firstUpdated(_changedProperties) {
-        super.firstUpdated(_changedProperties);
-/*
+  firstUpdated(_changedProperties) {
+    super.firstUpdated(_changedProperties);
+    /*
         if(this.querySelector('fx-label')){
             this.style.display = 'block';
         }
 */
-    }
+  }
 
-    /*
+  /*
         getControlValue() {
             // super.getControlValue();
             console.log('output control value ', this.value);
@@ -51,23 +49,19 @@ export class FxOutput extends XfAbstractControl {
         }
     */
 
-    isRequired () {
-        console.log('Output required');
-        return false;
-    }
+  isRequired() {
+    console.log('Output required');
+    return false;
+  }
 
-    isReadonly (){
-        return true;
-    }
+  isReadonly() {
+    return true;
+  }
 
-    handleRequired(mi) {
+  handleRequired(mi) {}
 
-    }
-
-    handleReadonly() {
-        // super.handleReadonly();
-    }
-
-
+  handleReadonly() {
+    // super.handleReadonly();
+  }
 }
 customElements.define('fx-output', FxOutput);

--- a/src/ui/fx-repeat.js
+++ b/src/ui/fx-repeat.js
@@ -1,8 +1,8 @@
-import "./fx-repeatitem.js";
-import * as fx from "fontoxpath";
+import './fx-repeatitem.js';
+import * as fx from 'fontoxpath';
 
-import {Fore} from "../fore";
-import {foreElementMixin} from "../ForeElementMixin";
+import { Fore } from '../fore';
+import { foreElementMixin } from '../ForeElementMixin';
 
 /**
  * `fx-repeat`
@@ -18,81 +18,80 @@ import {foreElementMixin} from "../ForeElementMixin";
  * @demo demo/todo.html
  */
 export class FxRepeat extends foreElementMixin(HTMLElement) {
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+      }
+    `;
+  }
 
-    static get styles() {
-        return css`
-            :host {
-              display: block;
-            }
-        `;
-    }
+  static get properties() {
+    return {
+      ...super.properties,
+      index: {
+        type: Number,
+      },
+      ref: {
+        type: String,
+      },
+      template: {
+        type: Object,
+      },
+      focusOnCreate: {
+        type: String,
+      },
+      initDone: {
+        type: Boolean,
+      },
+      repeatIndex: {
+        type: Number,
+      },
+      nodeset: {
+        type: Array,
+      },
+    };
+  }
 
-    static get properties() {
-        return {
-            ... super.properties,
-            index:{
-                type: Number
-            },
-            ref: {
-                type: String
-            },
-            template: {
-                type: Object
-            },
-            focusOnCreate: {
-                type: String
-            },
-            initDone: {
-                type: Boolean
-            },
-            repeatIndex:{
-                type: Number
-            },
-            nodeset:{
-                type: Array
-            }
-        };
-    }
+  constructor() {
+    super();
+    this.ref = '';
+    this.dataTemplate = [];
+    this.focusOnCreate = '';
+    this.initDone = false;
+    this.repeatIndex = 1;
+    this.nodeset = [];
+    this.inited = false;
+    this.index = 1;
+    this.repeatSize = 0;
+    this.attachShadow({ mode: 'open' });
+  }
 
-    constructor() {
-        super();
-        this.ref = '';
-        this.dataTemplate = [];
-        this.focusOnCreate = '';
-        this.initDone = false;
-        this.repeatIndex = 1;
-        this.nodeset = [];
-        this.inited = false;
-        this.index = 1;
-        this.repeatSize = 0;
-        this.attachShadow({mode:'open'});
-    }
+  get repeatSize() {
+    return this.querySelectorAll(':scope > fx-repeatitem').length;
+  }
 
-    get repeatSize(){
-        return this.querySelectorAll(':scope > fx-repeatitem').length;
-    }
+  set repeatSize(size) {
+    this.size = size;
+  }
 
-    set repeatSize(size){
-        this.size = size;
-    }
+  setIndex(index) {
+    // console.log('new repeat index ', index);
+    this.index = index;
+    const rItems = this.querySelectorAll(':scope > fx-repeatitem');
+    this._setIndex(rItems[this.index - 1]);
+  }
 
-    setIndex(index){
-        // console.log('new repeat index ', index);
-        this.index=index;
-        const rItems = this.querySelectorAll(':scope > fx-repeatitem');
-        this._setIndex(rItems[this.index-1]);
-    }
+  connectedCallback() {
+    this.ref = this.getAttribute('ref');
+    // console.log('### fx-repeat connected ', this.id);
+    this.addEventListener('index-changed', e => {
+      const { item } = e.detail;
+      const idx = Array.from(this.children).indexOf(item);
+      this._setIndex(this.children[idx]);
+    });
 
-    connectedCallback() {
-        this.ref=this.getAttribute('ref');
-        // console.log('### fx-repeat connected ', this.id);
-        this.addEventListener('index-changed', e => {
-           const {item} = e.detail;
-           const idx =  Array.from(this.children).indexOf(item);
-           this._setIndex(this.children[idx]);
-        });
-
-        const style = `
+    const style = `
             :host {
                 display: none;
             }
@@ -108,134 +107,128 @@ export class FxRepeat extends foreElementMixin(HTMLElement) {
                 animation: fade-out-bottom 0.7s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
             }
         `;
-        const html = `
+    const html = `
           <slot></slot>
         `;
-        this.shadowRoot.innerHTML = `
+    this.shadowRoot.innerHTML = `
             <style>
                 ${style}
             </style>
             ${html}
         `;
+  }
+
+  init() {
+    // ### there must be a single 'template' child
+    console.log('##### repeat init ', this.id);
+    // if(!this.inited) this.init();
+    // does not use this.evalInContext as it is expecting a nodeset instead of single node
+    this._evalNodeset();
+    // console.log('##### ',this.id, this.nodeset);
+
+    this._initTemplate();
+    this._initRepeatItems();
+
+    this.setAttribute('index', this.index);
+    this.inited = true;
+  }
+
+  /**
+   * repeat has no own modelItems
+   * @private
+   */
+  _evalNodeset() {
+    const inscope = this._inScopeContext();
+    // console.log('##### inscope ', inscope);
+    // console.log('##### ref ', this.ref);
+    this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
+  }
+
+  async refresh() {
+    console.group('fx-repeat.refresh on', this.id);
+
+    if (!this.inited) this.init();
+
+    const inscope = this._inScopeContext();
+    this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
+    // console.log('repeat refresh nodeset ', this.nodeset);
+
+    const repeatItems = this.querySelectorAll(':scope > fx-repeatitem');
+    const repeatItemCount = repeatItems.length;
+
+    let nodeCount = 1;
+    if (Array.isArray(this.nodeset)) {
+      nodeCount = this.nodeset.length;
     }
 
-    init() {
-        // ### there must be a single 'template' child
-        console.log('##### repeat init ',this.id);
-        // if(!this.inited) this.init();
-        // does not use this.evalInContext as it is expecting a nodeset instead of single node
-        this._evalNodeset();
-        // console.log('##### ',this.id, this.nodeset);
+    // const contextSize = this.nodeset.length;
+    const contextSize = nodeCount;
+    const modified = [];
+    if (contextSize < repeatItemCount) {
+      for (let position = repeatItemCount; position > contextSize; position--) {
+        // remove repeatitem
+        const itemToRemove = repeatItems[position - 1];
+        this._fadeOut(itemToRemove);
+        // setTimeout(itemToRemove.parentNode.removeChild(itemToRemove),1000);
+        // itemToRemove.parentNode.removeChild(itemToRemove);
+        // modified.push(itemToRemove);
+      }
 
-        this._initTemplate();
-        this._initRepeatItems();
-
-        this.setAttribute('index',this.index);
-        this.inited = true;
+      // todo: update index
     }
 
-    /**
-     * repeat has no own modelItems
-     * @private
-     */
-    _evalNodeset(){
-        const inscope = this._inScopeContext();
-        // console.log('##### inscope ', inscope);
-        // console.log('##### ref ', this.ref);
-        this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
+    if (contextSize > repeatItemCount) {
+      for (let position = repeatItemCount + 1; position <= contextSize; position++) {
+        // add new repeatitem
+
+        // const lastRepeatItem = repeatItems[repeatItemCount-1];
+        // const newItem = lastRepeatItem.cloneNode(true);
+
+        const newItem = document.createElement('fx-repeatitem');
+        const clonedTemplate = this._clone();
+
+        newItem.style.display = 'none';
+        newItem.appendChild(clonedTemplate);
+        this._fadeIn(newItem, 'block');
+        // const tmpl = this.shadowRoot.querySelector('template');
+        // const newItem = tmpl.content.cloneNode(true);
+
+        newItem.nodeset = this.nodeset[position - 1];
+        newItem.index = position;
+        this.appendChild(newItem);
+        modified.push(newItem);
+      }
     }
-
-    async refresh() {
-        console.group('fx-repeat.refresh on', this.id);
-
-        if(!this.inited) this.init();
-
-        const inscope = this._inScopeContext();
-        this.nodeset = fx.evaluateXPathToNodes(this.ref, inscope, null, {});
-        // console.log('repeat refresh nodeset ', this.nodeset);
-
-        let repeatItems = this.querySelectorAll(':scope > fx-repeatitem');
-        const repeatItemCount = repeatItems.length;
-
-        let nodeCount = 1;
-        if(Array.isArray(this.nodeset)){
-            nodeCount = this.nodeset.length;
-        }
-
-        // const contextSize = this.nodeset.length;
-        const contextSize = nodeCount;
-        const modified = [];
-        if (contextSize < repeatItemCount){
-
-            for(let position = repeatItemCount; position > contextSize; position--){
-                //remove repeatitem
-                const itemToRemove = repeatItems[position -1];
-                this._fadeOut(itemToRemove)
-                // setTimeout(itemToRemove.parentNode.removeChild(itemToRemove),1000);
-                // itemToRemove.parentNode.removeChild(itemToRemove);
-                // modified.push(itemToRemove);
-            }
-
-            //todo: update index
-        }
-
-        if(contextSize > repeatItemCount){
-
-            for(let position = repeatItemCount +1; position <= contextSize; position++){
-                //add new repeatitem
-
-                // const lastRepeatItem = repeatItems[repeatItemCount-1];
-                // const newItem = lastRepeatItem.cloneNode(true);
-
-
-                const newItem = document.createElement('fx-repeatitem');
-                const clonedTemplate = this._clone();
-
-                newItem.style.display='none';
-                newItem.appendChild(clonedTemplate);
-                this._fadeIn(newItem,'block');
-                // const tmpl = this.shadowRoot.querySelector('template');
-                // const newItem = tmpl.content.cloneNode(true);
-
-                newItem.nodeset = this.nodeset[position-1];
-                newItem.index = position;
-                this.appendChild(newItem);
-                modified.push(newItem);
-
-            }
-
-
-        }
-        if(modified.length > 0){
-            modified.forEach(mod => {
-                mod.refresh();
-            })
-        }
-        if(!this.inited){
-            Fore.refreshChildren(this);
-        }
-        if(contextSize === repeatItemCount){
-            Fore.refreshChildren(this);
-        }
-        console.groupEnd();
+    if (modified.length > 0) {
+      modified.forEach(mod => {
+        mod.refresh();
+      });
     }
+    if (!this.inited) {
+      Fore.refreshChildren(this);
+    }
+    if (contextSize === repeatItemCount) {
+      Fore.refreshChildren(this);
+    }
+    console.groupEnd();
+  }
 
-    _fadeIn(el, display){
-        el.style.opacity = 0;
-        el.style.display = display || "block";
+  _fadeIn(el, display) {
+    el.style.opacity = 0;
+    el.style.display = display || 'block';
 
-        (function fade() {
-            var val = parseFloat(el.style.opacity);
-            if (!((val += .1) > 1)) {
-                el.style.opacity = val;
-                requestAnimationFrame(fade);
-            }
-        })();
-    };
+    (function fade() {
+      let val = parseFloat(el.style.opacity);
+      if (!((val += 0.1) > 1)) {
+        el.style.opacity = val;
+        requestAnimationFrame(fade);
+      }
+    })();
+  }
 
-    _fadeOut(el){
-        el.classList.add('fade-out-bottom');
-/*
+  _fadeOut(el) {
+    el.classList.add('fade-out-bottom');
+    /*
         el.style.opacity = 1;
 
         (function fade() {
@@ -246,71 +239,69 @@ export class FxRepeat extends foreElementMixin(HTMLElement) {
             }
         })();
 */
+  }
 
-    };
+  _initTemplate() {
+    const shadowTemplate = this.shadowRoot.querySelector('template');
+    console.log('shadowtempl ', shadowTemplate);
 
+    const defaultSlot = this.shadowRoot.querySelector('slot');
+    const template = defaultSlot.assignedElements({ flatten: true })[0];
+    this.template = this.firstElementChild;
+    console.log('### init template for repeat ', this.id, this.template);
 
-    _initTemplate() {
-        const shadowTemplate = this.shadowRoot.querySelector('template');
-        console.log('shadowtempl ', shadowTemplate);
-
-        const defaultSlot = this.shadowRoot.querySelector('slot');
-        const template =  defaultSlot.assignedElements({flatten: true})[0];
-        this.template = this.firstElementChild;
-        console.log('### init template for repeat ', this.id , this.template);
-
-        if (this.template === null) {
-            // console.error('### no template found for this repeat:', this.id);
-            //todo: catch this on form element
-            this.dispatchEvent(new CustomEvent('no-template-error', {
-                composed: true,
-                bubbles: true,
-                detail: {"message": "no template found for repeat:" + this.id}
-            }));
-        }
-
-        this.shadowRoot.appendChild(this.template)
+    if (this.template === null) {
+      // console.error('### no template found for this repeat:', this.id);
+      // todo: catch this on form element
+      this.dispatchEvent(
+        new CustomEvent('no-template-error', {
+          composed: true,
+          bubbles: true,
+          detail: { message: `no template found for repeat:${this.id}` },
+        }),
+      );
     }
 
-    _initRepeatItems() {
-        // const model = this.getModel();
-        this.textContent = '';
-        this.nodeset.forEach((item, index) => {
+    this.shadowRoot.appendChild(this.template);
+  }
 
-            const repeatItem = document.createElement('fx-repeatitem');
-            repeatItem.nodeset = this.nodeset[index];
-            repeatItem.index = index +1; //1-based index
+  _initRepeatItems() {
+    // const model = this.getModel();
+    this.textContent = '';
+    this.nodeset.forEach((item, index) => {
+      const repeatItem = document.createElement('fx-repeatitem');
+      repeatItem.nodeset = this.nodeset[index];
+      repeatItem.index = index + 1; // 1-based index
 
-            const clone = this._clone();
-            repeatItem.appendChild(clone);
-            this.appendChild(repeatItem);
+      const clone = this._clone();
+      repeatItem.appendChild(clone);
+      this.appendChild(repeatItem);
 
-            if(repeatItem.index === 1){
-                this._setIndex(repeatItem);
-            }
-        });
+      if (repeatItem.index === 1) {
+        this._setIndex(repeatItem);
+      }
+    });
+  }
+
+  _clone() {
+    // const content = this.template.content.cloneNode(true);
+    this.template = this.shadowRoot.querySelector('template');
+    const content = this.template.content.cloneNode(true);
+    return document.importNode(content, true);
+  }
+
+  _setIndex(repeatItem) {
+    this._removeIndexMarker();
+    if (repeatItem) {
+      repeatItem.setAttribute('repeat-index', '');
     }
+  }
 
-    _clone() {
-        // const content = this.template.content.cloneNode(true);
-        this.template = this.shadowRoot.querySelector('template');
-        const content = this.template.content.cloneNode(true);
-        return document.importNode(content, true);
-    }
-
-    _setIndex(repeatItem){
-        this._removeIndexMarker();
-        if(repeatItem){
-            repeatItem.setAttribute('repeat-index','');
-        }
-    }
-
-    _removeIndexMarker() {
-        Array.from(this.children).forEach( item => {
-            item.removeAttribute('repeat-index');
-        });
-    }
-
+  _removeIndexMarker() {
+    Array.from(this.children).forEach(item => {
+      item.removeAttribute('repeat-index');
+    });
+  }
 }
 
 window.customElements.define('fx-repeat', FxRepeat);

--- a/src/ui/fx-repeatitem.js
+++ b/src/ui/fx-repeatitem.js
@@ -1,6 +1,5 @@
-import {Fore} from "../fore.js";
-import {foreElementMixin} from "../ForeElementMixin";
-
+import { Fore } from '../fore.js';
+import { foreElementMixin } from '../ForeElementMixin';
 
 /**
  * `fx-repeat`
@@ -10,8 +9,7 @@ import {foreElementMixin} from "../ForeElementMixin";
  * @demo demo/index.html
  */
 export class FxRepeatitem extends foreElementMixin(HTMLElement) {
-
-/*
+  /*
     static get styles() {
         return css`
             :host {
@@ -21,66 +19,66 @@ export class FxRepeatitem extends foreElementMixin(HTMLElement) {
     }
 */
 
-    static get properties() {
-        return {
-            inited:{
-                type:Boolean
-            }
-        };
+  static get properties() {
+    return {
+      inited: {
+        type: Boolean,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.inited = false;
+    this.addEventListener('click', this._dispatchIndexChange);
+    this.attachShadow({ mode: 'open' });
+  }
+
+  _dispatchIndexChange() {
+    console.log('_dispatchIndexChange on index ', this.index);
+    if (this.parentNode) {
+      this.parentNode.dispatchEvent(
+        new CustomEvent('index-changed', { composed: true, bubbles: true, detail: { item: this } }),
+      );
     }
+  }
 
-    constructor(){
-        super();
-        this.inited = false;
-        this.addEventListener('click', this._dispatchIndexChange)
-        this.attachShadow({mode:'open'});
-
-    }
-
-    _dispatchIndexChange(){
-        console.log('_dispatchIndexChange on index ', this.index);
-        if(this.parentNode){
-            this.parentNode.dispatchEvent(new CustomEvent('index-changed', {composed: true, bubbles: true, detail: {item:this}}));
-        }
-    }
-
-    connectedCallback(){
-        // super.connectedCallback();
-        // console.log('repeatItem connected ', this);
-        const html = `
+  connectedCallback() {
+    // super.connectedCallback();
+    // console.log('repeatItem connected ', this);
+    const html = `
            <slot></slot>
         `;
 
-        this.shadowRoot.innerHTML = `
+    this.shadowRoot.innerHTML = `
             ${html}
         `;
+  }
 
-    }
+  disconnectedCallback() {
+    console.log('disconnectedCallback ', this);
+    this.removeEventListener('click', this._dispatchIndexChange());
+  }
 
-    disconnectedCallback(){
-        console.log('disconnectedCallback ', this);
-        this.removeEventListener('click', this._dispatchIndexChange());
-    }
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
 
-    render() {
-        return html`
-            <slot></slot>
-        `;
-    }
+  init() {
+    // console.log('repeatitem init model ', this.nodeset);
+    // this._initializeChildren(this);
+    this.inited = true;
+  }
 
-    init(){
-        // console.log('repeatitem init model ', this.nodeset);
-        // this._initializeChildren(this);
-        this.inited = true;
-    }
+  getModelItem() {
+    super.getModelItem();
+    // console.log('modelItem in repeatitem ', this.getModelItem()[this.index]);
+    return this.getModelItem()[this.index];
+  }
 
-    getModelItem(){
-        super.getModelItem();
-        // console.log('modelItem in repeatitem ', this.getModelItem()[this.index]);
-        return this.getModelItem()[this.index];
-    }
-
-/*
+  /*
     _initializeChildren(node) {
         const children = Array.from(node.children);
         // console.log('_initializeChildren ', children);
@@ -99,7 +97,7 @@ export class FxRepeatitem extends foreElementMixin(HTMLElement) {
     }
 */
 
-/*
+  /*
     firstUpdated(_changedProperties) {
         // console.log('### fx-repeatitem firstUpdated index ', this.index);
         // console.log('### fx-repeatitem firstUpdated nodeset ', this.nodeset);
@@ -113,19 +111,18 @@ export class FxRepeatitem extends foreElementMixin(HTMLElement) {
     }
 */
 
-
-    refresh(){
-        // console.log('refresh repeatitem: ',this.nodeset);
-/*
+  refresh() {
+    // console.log('refresh repeatitem: ',this.nodeset);
+    /*
         if(!this.inited){
             this.init();
         }
 */
-        // console.log('refresh repeatitem nodeset: ',this.nodeset);
-        Fore.refreshChildren(this);
-    }
+    // console.log('refresh repeatitem nodeset: ',this.nodeset);
+    Fore.refreshChildren(this);
+  }
 
-/*
+  /*
     createRenderRoot() {
         /!**
          * Render template without shadow DOM. Note that shadow DOM features like
@@ -134,7 +131,6 @@ export class FxRepeatitem extends foreElementMixin(HTMLElement) {
         return this;
     }
 */
-
 }
 
 window.customElements.define('fx-repeatitem', FxRepeatitem);

--- a/src/ui/fx-switch.js
+++ b/src/ui/fx-switch.js
@@ -1,4 +1,4 @@
-import {foreElementMixin} from "../ForeElementMixin.js";
+import { foreElementMixin } from '../ForeElementMixin.js';
 
 /**
  * `fx-switch`
@@ -7,20 +7,18 @@ import {foreElementMixin} from "../ForeElementMixin.js";
  *  * todo: implement
  * @customElement
  */
-class FxSwitch extends foreElementMixin(HTMLElement){
+class FxSwitch extends foreElementMixin(HTMLElement) {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
 
-
-    constructor(){
-        super();
-        this.attachShadow({mode:'open'});
+  connectedCallback() {
+    if (this.hasAttribute('ref')) {
+      this.ref = this.getAttribute('ref');
     }
 
-    connectedCallback(){
-        if(this.hasAttribute('ref')){
-            this.ref=this.getAttribute('ref');
-        }
-
-        const style = `
+    const style = `
             :host {
                 display: block;
             }
@@ -28,47 +26,45 @@ class FxSwitch extends foreElementMixin(HTMLElement){
                 display:none;
             } 
         `;
-        const html = `
+    const html = `
            <slot></slot>
         `;
-        this.shadowRoot.innerHTML = `
+    this.shadowRoot.innerHTML = `
             <style>
                 ${style}
             </style>
             ${html}
         `;
 
-        const slot = this.shadowRoot.querySelector('slot');
-        slot.addEventListener('slotchange', (event) => {
-            console.log('fx-switch slotchange ', event.target.assignedElements())
-            const cases = event.target.assignedElements();
-            console.log('fx-switch slotchange ', cases[0]);
-            cases[0].style.display = "block";
-        });
+    const slot = this.shadowRoot.querySelector('slot');
+    slot.addEventListener('slotchange', event => {
+      console.log('fx-switch slotchange ', event.target.assignedElements());
+      const cases = event.target.assignedElements();
+      console.log('fx-switch slotchange ', cases[0]);
+      cases[0].style.display = 'block';
+    });
+  }
 
+  refresh() {
+    console.log('refresh on switch ');
+    if (this.ref) {
+      this.evalInContext();
+      this.modelItem = this.getModelItem();
+      this.value = this.modelItem.value;
     }
+    console.log('value ', this.value);
+  }
 
-    refresh(){
-        console.log('refresh on switch ');
-        if(this.ref){
-            this.evalInContext();
-            this.modelItem = this.getModelItem();
-            this.value = this.modelItem.value;
-        }
-        console.log('value ', this.value);
-    }
-
-    toggle(caseElement){
-        const cases = this.querySelectorAll('fx-case');
-        Array.from(cases).forEach(c => {
-            if(caseElement === c){
-                c.style.display = 'block';
-            }else {
-                c.style.display = 'none';
-            }
-        })
-    }
-
+  toggle(caseElement) {
+    const cases = this.querySelectorAll('fx-case');
+    Array.from(cases).forEach(c => {
+      if (caseElement === c) {
+        c.style.display = 'block';
+      } else {
+        c.style.display = 'none';
+      }
+    });
+  }
 }
 
 window.customElements.define('fx-switch', FxSwitch);

--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -9,18 +9,15 @@
  */
 
 module.exports = {
-  staticFileGlobs: [
-    'manifest.json',
-    'src/**/*',
-  ],
+  staticFileGlobs: ['manifest.json', 'src/**/*'],
   runtimeCaching: [
     {
       urlPattern: /\/@webcomponents\/webcomponentsjs\//,
-      handler: 'fastest'
+      handler: 'fastest',
     },
     {
       urlPattern: /^https:\/\/fonts.gstatic.com\//,
-      handler: 'fastest'
-    }
-  ]
+      handler: 'fastest',
+    },
+  ],
 };

--- a/test/bind.test.js
+++ b/test/bind.test.js
@@ -1,5 +1,13 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../src/fx-instance.js';
 import '../src/ui/fx-container.js';
@@ -7,52 +15,46 @@ import '../src/fx-bind.js';
 import { ModelItem } from '../src/ModelItem.js';
 
 describe('bind Tests', () => {
+  it('is initialized', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="b-greeting" ref="greeting" required="1 = 1"></fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-    it('is initialized', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="b-greeting" ref="greeting" required="1 = 1"></fx-bind>
-                    </fx-model>
-                </fx-form>               
-            `)
-        );
+    await elementUpdated(el);
+    const bind = document.getElementById('b-greeting');
+    expect(bind).to.exist;
+    expect(bind.instanceId).to.equal('default');
 
-        await elementUpdated(el);
-        const bind = document.getElementById('b-greeting');
-        expect(bind).to.exist;
-        expect(bind.instanceId).to.equal('default');
+    const model = document.getElementById('model1');
+    expect(model.modelItems.length).to.equal(1);
 
-        const model = document.getElementById('model1');
-        expect(model.modelItems.length).to.equal(1);
+    const mi = model.modelItems[0];
+    expect(mi.node instanceof Node).to.equal(true);
 
-        const mi = model.modelItems[0];
-        expect((mi.node instanceof Node)).to.equal(true);
+    console.log('*****', mi);
+    // expect(mi.modelItem.value).to.exist;
+    expect(mi.node.textContent).to.equal('Hello World!');
+    expect(mi.node).to.equal(mi.node);
 
-        console.log('*****',mi);
-        // expect(mi.modelItem.value).to.exist;
-        expect(mi.node.textContent).to.equal('Hello World!');
-        expect(mi.node).to.equal(mi.node);
+    expect(mi.readonly).to.exist;
+    expect(mi.required).to.exist;
+    expect(mi.required).to.equal(true);
 
+    expect(mi.relevant).to.exist;
+    expect(mi.constraint).to.exist;
+    // expect(mi.modelItem.type).to.exist;
+  });
 
-        expect(mi.readonly).to.exist;
-        expect(mi.required).to.exist;
-        expect(mi.required).to.equal(true);
-
-        expect(mi.relevant).to.exist;
-        expect(mi.constraint).to.exist;
-        // expect(mi.modelItem.type).to.exist;
-
-
-    });
-
-/*
+  /*
     it('works with nested attribute', async () => {
         const el =  (
             await fixtureSync(html`
@@ -88,189 +90,168 @@ describe('bind Tests', () => {
     });
 */
 
-    it('works with nested element', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>
-                                    <message>Hello World!</message>
-                                </greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="b-greeting" ref="greeting">
-                            <fx-bind id="b-message" ref="message"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>               
-            `)
-        );
+  it('works with nested element', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>
+                <message>Hello World!</message>
+              </greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="b-greeting" ref="greeting">
+            <fx-bind id="b-message" ref="message"></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const bind1 = document.getElementById('b-greeting');
-        expect(bind1).to.exist;
-        const bind2 = document.getElementById('b-message');
-        expect(bind2).to.exist;
+    await elementUpdated(el);
+    const bind1 = document.getElementById('b-greeting');
+    expect(bind1).to.exist;
+    const bind2 = document.getElementById('b-message');
+    expect(bind2).to.exist;
 
-        const model = document.getElementById('model1');
-        expect(model.modelItems.length).to.equal(2);
+    const model = document.getElementById('model1');
+    expect(model.modelItems.length).to.equal(2);
 
-        const mi = model.modelItems[1];
-        expect(mi.node).to.exist;
-        expect(mi.node.textContent).to.equal('Hello World!');
-    });
+    const mi = model.modelItems[1];
+    expect(mi.node).to.exist;
+    expect(mi.node.textContent).to.equal('Hello World!');
+  });
 
-    it('works with nested dot reference', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="greeting" ref="greeting">
-                            <fx-bind ref="."></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>               
-            `)
-        );
+  it('works with nested dot reference', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="greeting" ref="greeting">
+            <fx-bind ref="."></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const bind1 = document.getElementById('greeting');
-        expect(bind1).to.exist;
+    await elementUpdated(el);
+    const bind1 = document.getElementById('greeting');
+    expect(bind1).to.exist;
 
-        const model = document.getElementById('model1');
-        expect(model.modelItems.length).to.equal(1);
+    const model = document.getElementById('model1');
+    expect(model.modelItems.length).to.equal(1);
+  });
 
-    });
+  it('works for repeated element', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-    it('works for repeated element', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind id="task" ref="task">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-            
-                </fx-form>
-            `)
-        );
+          <fx-bind id="task" ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const bind1 = document.getElementById('task');
-        expect(bind1).to.exist;
-        expect(bind1.nodeset.length).to.equal(2);
-        expect(bind1.nodeset[0].nodeName).to.equal('task');
-        expect(bind1.nodeset[0].nodeType).to.equal(1);
-        expect(bind1.nodeset[0].textContent).to.equal('Pick up Milk');
-        expect(bind1.nodeset[1].nodeName).to.equal('task');
-        expect(bind1.nodeset[1].nodeType).to.equal(1);
-        expect(bind1.nodeset[1].textContent).to.equal('Make tutorial part 1');
+    await elementUpdated(el);
+    const bind1 = document.getElementById('task');
+    expect(bind1).to.exist;
+    expect(bind1.nodeset.length).to.equal(2);
+    expect(bind1.nodeset[0].nodeName).to.equal('task');
+    expect(bind1.nodeset[0].nodeType).to.equal(1);
+    expect(bind1.nodeset[0].textContent).to.equal('Pick up Milk');
+    expect(bind1.nodeset[1].nodeName).to.equal('task');
+    expect(bind1.nodeset[1].nodeType).to.equal(1);
+    expect(bind1.nodeset[1].textContent).to.equal('Make tutorial part 1');
 
+    const model = document.getElementById('record');
+    expect(model.modelItems.length).to.equal(6);
 
-        const model = document.getElementById('record');
-        expect(model.modelItems.length).to.equal(6);
+    console.log('model', model.modelItems);
+    expect(model.modelItems[0].node.nodeType).to.equal(1);
+    expect(model.modelItems[0].node.textContent).to.equal('Pick up Milk');
 
-        console.log('model', model.modelItems);
-        expect(model.modelItems[0].node.nodeType).to.equal(1);
-        expect(model.modelItems[0].node.textContent).to.equal('Pick up Milk');
+    expect(model.modelItems[1].node.nodeType).to.equal(1);
+    expect(model.modelItems[1].node.textContent).to.equal('Make tutorial part 1');
 
-        expect(model.modelItems[1].node.nodeType).to.equal(1);
-        expect(model.modelItems[1].node.textContent).to.equal('Make tutorial part 1');
+    expect(model.modelItems[2].node.nodeType).to.equal(2);
+    expect(model.modelItems[2].value).to.equal('false');
 
-        expect(model.modelItems[2].node.nodeType).to.equal(2);
-        expect(model.modelItems[2].value).to.equal('false');
+    expect(model.modelItems[3].node.nodeType).to.equal(2);
+    expect(model.modelItems[3].value).to.equal('true');
 
-        expect(model.modelItems[3].node.nodeType).to.equal(2);
-        expect(model.modelItems[3].value).to.equal('true');
+    expect(model.modelItems[4].node.nodeType).to.equal(2);
+    expect(model.modelItems[4].node.textContent).to.equal('2019-02-04');
 
-        expect(model.modelItems[4].node.nodeType).to.equal(2);
-        expect(model.modelItems[4].node.textContent).to.equal('2019-02-04');
+    expect(model.modelItems[5].node.nodeType).to.equal(2);
+    expect(model.modelItems[5].node.textContent).to.equal('2019-01-04');
+  });
 
-        expect(model.modelItems[5].node.nodeType).to.equal(2);
-        expect(model.modelItems[5].node.textContent).to.equal('2019-01-04');
+  it('combines facets for dot reference', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="greeting" ref="greeting">
+            <fx-bind ref="." required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-    });
+    await elementUpdated(el);
+    const bind1 = document.getElementById('greeting');
+    expect(bind1).to.exist;
 
+    const model = document.getElementById('model1');
+    expect(model.modelItems.length).to.equal(1);
+    expect(model.modelItems[0].required).to.equal(true);
+  });
 
-    it('combines facets for dot reference', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="greeting" ref="greeting">
-                            <fx-bind ref="." required="true()"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>               
-            `)
-        );
+  it('uses closest binding expr', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="greeting" ref="greeting">
+            <fx-bind required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const bind1 = document.getElementById('greeting');
-        expect(bind1).to.exist;
+    await elementUpdated(el);
+    const bind1 = document.getElementById('greeting');
+    expect(bind1).to.exist;
 
-        const model = document.getElementById('model1');
-        expect(model.modelItems.length).to.equal(1);
-        expect(model.modelItems[0].required).to.equal(true);
+    const model = document.getElementById('model1');
+    expect(model.modelItems.length).to.equal(1);
+    console.log('++++++++++++++++++++++++++++ ', model.modelItems);
+    expect(model.modelItems[0].required).to.equal(true);
+  });
 
-    });
-
-
-    it('uses closest binding expr', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="greeting" ref="greeting">
-                            <fx-bind required="true()"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>               
-            `)
-        );
-
-        await elementUpdated(el);
-        const bind1 = document.getElementById('greeting');
-        expect(bind1).to.exist;
-
-        const model = document.getElementById('model1');
-        expect(model.modelItems.length).to.equal(1);
-        console.log('++++++++++++++++++++++++++++ ', model.modelItems);
-        expect(model.modelItems[0].required).to.equal(true);
-
-    });
-
-/*
+  /*
     it('hides non-relevant (unbound) controls', async () => {
         const el =  (
             await fixtureSync(html`
@@ -308,68 +289,63 @@ describe('bind Tests', () => {
     });
 */
 
-    it('nested binding are working', async () => {
-        const el =  (
-            await fixture(html`
-                 <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting type="message">Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="b-greeting" ref="greeting" required="1 = 1">
-                            <fx-bind id="b-type" ref="@type"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                    <fx-group>
-                        <fx-output id="output1" ref="greeting"> </fx-output> : <fx-output id="output2" ref="greeting/@type"></fx-output>
-                    </fx-group>
-                </fx-form>               
-            `)
-        );
+  it('nested binding are working', async () => {
+    const el = await fixture(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting type="message">Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="b-greeting" ref="greeting" required="1 = 1">
+            <fx-bind id="b-type" ref="@type"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <fx-output id="output1" ref="greeting"> </fx-output> :
+          <fx-output id="output2" ref="greeting/@type"></fx-output>
+        </fx-group>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const bind = document.getElementById('b-greeting');
-        expect(bind).to.exist;
+    await elementUpdated(el);
+    const bind = document.getElementById('b-greeting');
+    expect(bind).to.exist;
 
-        const model = document.getElementById('model1');
-        expect(model.modelItems.length).to.equal(2);
+    const model = document.getElementById('model1');
+    expect(model.modelItems.length).to.equal(2);
 
-        //check the modelitems
-        const mi = model.modelItems[0];
-        expect(mi.node).to.exist;
-        expect(mi.node.textContent).to.equal('Hello World!');
+    // check the modelitems
+    const mi = model.modelItems[0];
+    expect(mi.node).to.exist;
+    expect(mi.node.textContent).to.equal('Hello World!');
 
-        const mi2 = model.modelItems[1];
-        expect(mi2.node).to.exist;
-        expect(mi2.node.nodeType).to.equal(2);//attribute
-        expect(mi2.node.nodeName).to.equal("type");//attribute
-        expect(mi2.node.textContent).to.equal('message');
+    const mi2 = model.modelItems[1];
+    expect(mi2.node).to.exist;
+    expect(mi2.node.nodeType).to.equal(2); // attribute
+    expect(mi2.node.nodeName).to.equal('type'); // attribute
+    expect(mi2.node.textContent).to.equal('message');
 
-        //check the controls
-        const out1 = document.getElementById('output1');
-        expect(out1.nodeName).to.equal('FX-OUTPUT');
-        expect(out1.modelItem).to.exist;
-        console.log('modelItem ', out1.getModelItem());
+    // check the controls
+    const out1 = document.getElementById('output1');
+    expect(out1.nodeName).to.equal('FX-OUTPUT');
+    expect(out1.modelItem).to.exist;
+    console.log('modelItem ', out1.getModelItem());
 
-        expect(out1.getModelItem()).to.equal(mi);
-        expect(out1.getModelItem().node.nodeType).to.equal(1);
-        expect(out1.ref).to.equal('greeting');
-        expect(out1.getModelItem().value).to.equal('Hello World!');
+    expect(out1.getModelItem()).to.equal(mi);
+    expect(out1.getModelItem().node.nodeType).to.equal(1);
+    expect(out1.ref).to.equal('greeting');
+    expect(out1.getModelItem().value).to.equal('Hello World!');
 
+    expect(out1.value).to.equal('Hello World!');
 
-        expect(out1.value).to.equal('Hello World!');
-
-        const out2 = document.getElementById('output2');
-        expect(out2.nodeName).to.equal('FX-OUTPUT');
-        expect(out2.nodeset).to.exist;
-        console.log('++++++++++++ nodeset ',out2.nodeset);
-        console.log('++++++++++++ nodeset ',out2.nodeset.parentNode);
-        expect(out2.ref).to.equal('greeting/@type');
-        expect(out2.value).to.equal('message');
-    });
-
-
-
+    const out2 = document.getElementById('output2');
+    expect(out2.nodeName).to.equal('FX-OUTPUT');
+    expect(out2.nodeset).to.exist;
+    console.log('++++++++++++ nodeset ', out2.nodeset);
+    console.log('++++++++++++ nodeset ', out2.nodeset.parentNode);
+    expect(out2.ref).to.equal('greeting/@type');
+    expect(out2.value).to.equal('message');
+  });
 });

--- a/test/bound.test.js
+++ b/test/bound.test.js
@@ -1,5 +1,13 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../src/fx-form.js';
 import '../src/fx-model.js';
@@ -9,108 +17,94 @@ import '../src/ui/fx-output.js';
 import '../src/ui/fx-control.js';
 
 describe('fx-control tests', () => {
+  it('is initialized', async () => {
+    const el = await fixture(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <item>foobar</item>
+              <checked>true</checked>
+            </data>
+            <fx-bind ref="item"></fx-bind>
+            <fx-bind ref="checked"></fx-bind>
+          </fx-instance>
+        </fx-model>
+        <fx-group>
+          <fx-control id="input1" ref="item" update-event="blur" value-prop="value">
+            <label slot="label">with onblur handler</label>
+            <input id="control" name="value" value="" />
+          </fx-control>
+        </fx-group>
+      </fx-form>
+    `);
 
-    it('is initialized', async () => {
-        const el =  (
-            await fixture(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <item>foobar</item>
-                                <checked>true</checked>
-                            </data>
-                            <fx-bind ref="item"></fx-bind>
-                            <fx-bind ref="checked"></fx-bind>
-                        </fx-instance>
-                    </fx-model>
-                    <fx-group>
-                        <fx-control id="input1" ref="item" update-event="blur" value-prop="value">
-                            <label slot="label">with onblur handler</label>
-                            <input id="control" name="value" value="">
-                        </fx-control>
-                
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+    await elementUpdated(el);
+    const bound = el.querySelector('#input1');
+    expect(bound).to.exist;
 
-        await elementUpdated(el);
-        const bound = el.querySelector('#input1');
-        expect(bound).to.exist;
+    const control = document.getElementById('control');
+    expect(bound.control).to.equal(control);
+  });
 
-        const control = document.getElementById('control');
-        expect(bound.control).to.equal(control);
+  it('is creates a default input', async () => {
+    const el = await fixture(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <item>foobar</item>
+              <checked>true</checked>
+            </data>
+            <fx-bind ref="item"></fx-bind>
+            <fx-bind ref="checked"></fx-bind>
+          </fx-instance>
+        </fx-model>
+        <fx-group>
+          <fx-control id="input1" ref="item">
+            <label slot="label">with onblur handler</label>
+          </fx-control>
+        </fx-group>
+      </fx-form>
+    `);
 
-    });
+    await elementUpdated(el);
+    const bound = el.querySelector('#input1');
+    expect(bound).to.exist;
 
-    it('is creates a default input', async () => {
-        const el =  (
-            await fixture(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <item>foobar</item>
-                                <checked>true</checked>
-                            </data>
-                            <fx-bind ref="item"></fx-bind>
-                            <fx-bind ref="checked"></fx-bind>
-                        </fx-instance>
-                    </fx-model>
-                    <fx-group>
-                        <fx-control id="input1" ref="item">
-                            <label slot="label">with onblur handler</label>
-                        </fx-control>
-                
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+    const input = bound.control;
+    expect(input).to.exist;
+  });
 
-        await elementUpdated(el);
-        const bound = el.querySelector('#input1');
-        expect(bound).to.exist;
+  it('is initialized', async () => {
+    const el = await fixture(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <item>foobar</item>
+              <checked>true</checked>
+            </data>
+            <fx-bind ref="item"></fx-bind>
+            <fx-bind ref="checked"></fx-bind>
+          </fx-instance>
+        </fx-model>
+        <fx-group>
+          <fx-control id="input1" ref="item" update-event="blur" value-prop="value">
+            <label slot="label">with onblur handler</label>
+            <input name="value" value="" />
+          </fx-control>
+        </fx-group>
+      </fx-form>
+    `);
 
-        const input = bound.control;
-        expect(input).to.exist;
+    await elementUpdated(el);
+    const bound = el.querySelector('#input1');
+    expect(bound).to.exist;
+  });
 
-    });
-
-    it('is initialized', async () => {
-        const el =  (
-            await fixture(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <item>foobar</item>
-                                <checked>true</checked>
-                            </data>
-                            <fx-bind ref="item"></fx-bind>
-                            <fx-bind ref="checked"></fx-bind>
-                        </fx-instance>
-                    </fx-model>
-                    <fx-group>
-                        <fx-control id="input1" ref="item" update-event="blur" value-prop="value">
-                            <label slot="label">with onblur handler</label>
-                            <input name="value" value="">
-                        </fx-control>
-                
-                    </fx-group>
-                </fx-form>
-            `)
-        );
-
-        await elementUpdated(el);
-        const bound = el.querySelector('#input1');
-        expect(bound).to.exist;
-
-    });
-
-    it('it updates when update event fires', async () => {
-        const el =  (
-            await fixture(html`
+  it('it updates when update event fires', async () => {
+    const el = await fixture(html`
                 <fx-form>
                     <fx-model id="model1">
                         <fx-instance>
@@ -131,27 +125,21 @@ describe('fx-control tests', () => {
                     </fx-group>
                     <fx-setvalue event="refresh-done" ref="item"">foo</fx-setvalue>
                 </fx-form>
-            `)
-        );
+            `);
 
-        // await elementUpdated(el);
+    // await elementUpdated(el);
 
-        const bound = el.querySelector('#input1');
-        expect(bound).to.exist;
+    const bound = el.querySelector('#input1');
+    expect(bound).to.exist;
 
+    const i1 = document.getElementById('input1');
+    i1.value = 'foo';
+    i1.blur();
+    expect(i1.value).to.equal('foo');
+  });
 
-        const i1 = document.getElementById('input1');
-        i1.value = "foo";
-        i1.blur();
-        expect(i1.value).to.equal('foo');
-
-
-
-    });
-
-    it('initialzes native select', async () => {
-        const el =  (
-            await fixture(html`
+  it('initialzes native select', async () => {
+    const el = await fixture(html`
                 <fx-form>
                     <fx-model>
                         <fx-instance>
@@ -171,26 +159,22 @@ describe('fx-control tests', () => {
                         </fx-control>
                     </fx-group>
                 </fx-form>
-            `)
-        );
+            `);
 
-        // await elementUpdated(el);
+    // await elementUpdated(el);
 
-        const bound = el.querySelector('fx-control');
-        expect(bound).to.exist;
-        expect(bound.valueProp).to.equal('value');
-        expect(bound[bound.valueProp]).to.equal('foo');
+    const bound = el.querySelector('fx-control');
+    expect(bound).to.exist;
+    expect(bound.valueProp).to.equal('value');
+    expect(bound[bound.valueProp]).to.equal('foo');
 
-        const select = el.querySelector('select');
-        expect(select).to.exist;
-        console.log('select value ', select.value);
-        expect(select.value).to.equal('foo');
+    const select = el.querySelector('select');
+    expect(select).to.exist;
+    console.log('select value ', select.value);
+    expect(select.value).to.equal('foo');
+  });
 
-
-
-    });
-
-/*
+  /*
     it('is initialized', async () => {
         const el =  (
             await fixture(html`
@@ -231,8 +215,4 @@ describe('fx-control tests', () => {
 
     });
 */
-
-
-
-
 });

--- a/test/control.test.js
+++ b/test/control.test.js
@@ -1,96 +1,97 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../index.js';
 
 describe('control tests', () => {
+  it('shows control alert defined on control', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <a>Aa</a>
+              <b>B</b>
+              <c>C</c>
+            </data>
+          </fx-instance>
 
-    it('shows control alert defined on control', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <a>Aa</a>
-                                <b>B</b>
-                                <c>C</c>
-                            </data>
-                        </fx-instance>
-                
-                        <fx-bind ref="a" constraint="string-length(.) = 1"></fx-bind>
-                        <fx-bind ref="b" constraint="string-length(.) = 1" alert="string must be exactly one character long"></fx-bind>
-                        <fx-bind ref="c" constraint="string-length(.) = 1">
-                            <fx-alert><b>string must be exactly 1 character long</b></fx-alert>
-                        </fx-bind>
-                    </fx-model>
-                    
-                    <fx-input id="input1" label="A-label" ref="a">
-                        <fx-alert>Constraint not valid</fx-alert>
-                        <fx-hint>must be one character long</fx-hint>
-                    </fx-input>
+          <fx-bind ref="a" constraint="string-length(.) = 1"></fx-bind>
+          <fx-bind
+            ref="b"
+            constraint="string-length(.) = 1"
+            alert="string must be exactly one character long"
+          ></fx-bind>
+          <fx-bind ref="c" constraint="string-length(.) = 1">
+            <fx-alert><b>string must be exactly 1 character long</b></fx-alert>
+          </fx-bind>
+        </fx-model>
 
-                    <fx-input id="input2" label="B-label" ref="b">
-                        <fx-alert id="alert1">Constraint not valid</fx-alert>
-                        <fx-hint>must be one character long</fx-hint>
-                    </fx-input>
+        <fx-input id="input1" label="A-label" ref="a">
+          <fx-alert>Constraint not valid</fx-alert>
+          <fx-hint>must be one character long</fx-hint>
+        </fx-input>
 
-                </fx-form>`)
-        );
+        <fx-input id="input2" label="B-label" ref="b">
+          <fx-alert id="alert1">Constraint not valid</fx-alert>
+          <fx-hint>must be one character long</fx-hint>
+        </fx-input>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
+    await elementUpdated(el);
 
-        // let { detail } = await oneEvent(el, 'refresh-done');
+    // let { detail } = await oneEvent(el, 'refresh-done');
 
-        /*
+    /*
         WOW - crazy - using an id of 'input' somehow makes SVG from the controls - weird
          */
-        const input = document.getElementById('input1');
-        const alert1 = document.getElementById('alert1');
-        console.log('alert1 ', alert1);
-        expect(alert1).to.exist;
-        expect(alert1).to.be.visible;
-        expect(alert1.firstElementChild).to.be.null; // should not contain further elements
+    const input = document.getElementById('input1');
+    const alert1 = document.getElementById('alert1');
+    console.log('alert1 ', alert1);
+    expect(alert1).to.exist;
+    expect(alert1).to.be.visible;
+    expect(alert1.firstElementChild).to.be.null; // should not contain further elements
 
+    const input2 = document.getElementById('input2');
+    const alert2 = input2.firstElementChild;
+    console.log('alert 21 ', alert2);
+    expect(alert1).to.exist;
+    expect(alert2.getAttribute('style')).to.equal('display: none;');
+  });
 
-        const input2 = document.getElementById('input2');
-        const alert2 = input2.firstElementChild;
-        console.log('alert 21 ', alert2);
-        expect(alert1).to.exist;
-        expect(alert2.getAttribute('style')).to.equal('display: none;');
+  it('has a control child with value "A"', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <a>A</a>
+            </data>
+          </fx-instance>
+        </fx-model>
 
+        <fx-input id="input1" label="A-label" ref="a"> </fx-input>
+      </fx-form>
+    `);
 
+    await elementUpdated(el);
+    // let { detail } = await oneEvent(el, 'refresh-done');
+    const input = document.getElementById('input1');
+    expect(input.control).to.exist;
+    console.log('control value ', input.control);
+    expect(input.control.value).to.equal('A');
+  });
 
-    });
-
-    it('has a control child with value "A"', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">  
-                        <fx-instance>
-                            <data>
-                                <a>A</a>
-                            </data>
-                        </fx-instance>
-                
-                    </fx-model>
-                    
-                    <fx-input id="input1" label="A-label" ref="a">
-                    </fx-input>
-
-                </fx-form>`)
-        );
-
-        await elementUpdated(el);
-        // let { detail } = await oneEvent(el, 'refresh-done');
-        const input = document.getElementById('input1');
-        expect(input.control).to.exist;
-        console.log('control value ', input.control);
-        expect(input.control.value).to.equal('A');
-    });
-
-/*
+  /*
     it('listens for event', async () => {
         const el =  (
             await fixtureSync(html`
@@ -143,7 +144,4 @@ describe('control tests', () => {
 
     });
 */
-
-
-
 });

--- a/test/form.test.js
+++ b/test/form.test.js
@@ -1,5 +1,14 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE, waitUntil } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+  waitUntil,
+} from '@open-wc/testing';
 
 import '../src/fx-form.js';
 import '../src/fx-model.js';
@@ -7,134 +16,115 @@ import '../src/fx-instance.js';
 import '../src/fx-bind.js';
 
 describe('initialize form', () => {
+  it('model emits model-construct-done', async () => {
+    const el = await fixtureSync(html`
+      <fx-model id="model1"> </fx-model>
+    `);
 
+    setTimeout(() => el.modelConstruct());
 
-    it('model emits model-construct-done', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-model id="model1">
-                </fx-model>   
-            `)
-        );
+    const { detail } = await oneEvent(el, 'model-construct-done');
+    expect(detail.model.id).to.equal('model1');
+  });
 
-        setTimeout(() => el.modelConstruct());
+  it('ready event is emitted after first complete render', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting type="message:">Hello World!</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
+      </fx-form>
+    `);
 
-        let { detail } = await oneEvent(el, 'model-construct-done');
-        expect(detail.model.id).to.equal('model1');
+    const { detail } = await oneEvent(el, 'ready');
+    expect(el.ready).to.be.true;
+  });
 
-    });
+  it('initialized model', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-instance id="second">
+            <data>
+              <outro>GoodBye</outro>
+            </data>
+          </fx-instance>
+          <fx-bind id="b-greeting" ref="greeting" required="1 = 1"></fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
+    const model = el.querySelector('fx-model');
+    // await model.updated();
+    await elementUpdated(model);
+    expect(model).to.exist;
+    expect(model.id).to.equal('model1');
+    expect(model.instances.length).to.equal(2);
+  });
 
-    it('ready event is emitted after first complete render', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting type="message:">Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                    </fx-model>
-                </fx-form>
-            `)
-        );
+  it('created modelItem', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+          <fx-instance id="second">
+            <data>
+              <greeting>GoodBye</greeting>
+            </data>
+          </fx-instance>
+          <fx-bind id="b-greeting" ref="greeting" required="1 = 1"></fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
+    const model = el.querySelector('fx-model');
+    // await model.updated();
+    await elementUpdated(model);
 
-        let { detail } = await oneEvent(el, 'ready');
-        expect(el.ready).to.be.true;
+    // there is one binding
+    expect(el.model.modelItems.length).to.equal(1);
 
-    });
+    const greetingMap = el.model.modelItems[0];
 
+    // binding refers to <greeting> node
+    expect(greetingMap.node.nodeName).to.equal('greeting');
 
+    // modelitem is initialized to correct values
+    const mi = greetingMap;
+    expect(mi.readonly).to.equal(false);
+    expect(mi.required).to.equal(true);
+    expect(mi.relevant).to.equal(true);
+    expect(mi.constraint).to.equal(true);
+    // expect(mi.type).to.equal('xs:string');
+  });
 
-    it('initialized model', async () => {
-        const el = (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-instance id="second">
-                            <data>
-                                <outro>GoodBye</outro>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="b-greeting" ref="greeting" required="1 = 1"></fx-bind>
-                    </fx-model>
-                </fx-form>
-            `)
-        );
-        const model = el.querySelector('fx-model');
-        // await model.updated();
-        await elementUpdated(model);
-        expect(model).to.exist;
-        expect(model.id).to.equal('model1');
-        expect(model.instances.length).to.equal(2);
-    });
-
-    it('created modelItem', async () => {
-        const el = (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-instance id="second">
-                            <data>
-                                <greeting>GoodBye</greeting>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="b-greeting" ref="greeting" required="1 = 1"></fx-bind>
-                    </fx-model>
-                </fx-form>
-            `)
-        );
-        const model = el.querySelector('fx-model');
-        // await model.updated();
-        await elementUpdated(model);
-
-        // there is one binding
-        expect(el.model.modelItems.length).to.equal(1);
-
-        const greetingMap = el.model.modelItems[0];
-
-        //binding refers to <greeting> node
-        expect(greetingMap.node.nodeName).to.equal('greeting');
-
-        // modelitem is initialized to correct values
-        const mi = greetingMap;
-        expect(mi.readonly).to.equal(false);
-        expect(mi.required).to.equal(true);
-        expect(mi.relevant).to.equal(true);
-        expect(mi.constraint).to.equal(true);
-        // expect(mi.type).to.equal('xs:string');
-    });
-
-    it('has paper-dialog', async () => {
-        const el = (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model>
-                        <fx-instance>
-                            <data></data>
-                        </fx-instance>
-                    </fx-model>
-                </fx-form>
-            `)
-        );
-        // await model.updated();
-        // await elementUpdated(el);
-        let { detail } = await oneEvent(el, 'refresh-done');
-        console.log('el ',el);
-        const dialog = el.shadowRoot.querySelector('paper-dialog');
-        expect(dialog).to.exist;
-        expect(dialog.id).to.be.equal('modalMessage');
-    });
-
-
+  it('has paper-dialog', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model>
+          <fx-instance>
+            <data></data>
+          </fx-instance>
+        </fx-model>
+      </fx-form>
+    `);
+    // await model.updated();
+    // await elementUpdated(el);
+    const { detail } = await oneEvent(el, 'refresh-done');
+    console.log('el ', el);
+    const dialog = el.shadowRoot.querySelector('paper-dialog');
+    expect(dialog).to.exist;
+    expect(dialog.id).to.be.equal('modalMessage');
+  });
 });

--- a/test/lazy.test.js
+++ b/test/lazy.test.js
@@ -1,108 +1,103 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../index.js';
 
 describe('lazy initialize', () => {
+  it('creates modelItem during refresh', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-message event="refresh-done">refresh has been done</fx-message>
 
-    it('creates modelItem during refresh', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-message event="refresh-done">refresh has been done</fx-message>
-                
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting type="message:">Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                    </fx-model>
-                    
-                    <fx-group>
-                        <h1 class="{class}">
-                            lazy greeting
-                        </h1>
-                        <fx-output id="output" ref="greeting/@type"></fx-output>
-                        <fx-output id="output" ref="greeting"></fx-output>
-                    </fx-group>
-                </fx-form>`)
-        );
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting type="message:">Hello World!</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
 
+        <fx-group>
+          <h1 class="{class}">
+            lazy greeting
+          </h1>
+          <fx-output id="output" ref="greeting/@type"></fx-output>
+          <fx-output id="output" ref="greeting"></fx-output>
+        </fx-group>
+      </fx-form>
+    `);
 
-        let { detail } = await oneEvent(el, 'refresh-done');
-        const model = el.querySelector('fx-model');
-        console.log('modelitems ', model.modelItems);
-        expect(model.modelItems.length).to.equal(2);
+    const { detail } = await oneEvent(el, 'refresh-done');
+    const model = el.querySelector('fx-model');
+    console.log('modelitems ', model.modelItems);
+    expect(model.modelItems.length).to.equal(2);
 
-        const mi1 = model.modelItems[0];
-        expect(mi1.value).to.equal('message:');
-        expect(mi1.readonly).to.equal(false);
-        expect(mi1.required).to.equal(false);
-        expect(mi1.relevant).to.equal(true);
-        expect(mi1.constraint).to.equal(true);
-        expect(mi1.type).to.equal('xs:string');
-        expect(mi1.path).to.equal('/greeting[1]/@type');
+    const mi1 = model.modelItems[0];
+    expect(mi1.value).to.equal('message:');
+    expect(mi1.readonly).to.equal(false);
+    expect(mi1.required).to.equal(false);
+    expect(mi1.relevant).to.equal(true);
+    expect(mi1.constraint).to.equal(true);
+    expect(mi1.type).to.equal('xs:string');
+    expect(mi1.path).to.equal('/greeting[1]/@type');
 
+    const mi2 = model.modelItems[1];
+    expect(mi2.value).to.equal('Hello World!');
+    expect(mi2.readonly).to.equal(false);
+    expect(mi2.required).to.equal(false);
+    expect(mi2.relevant).to.equal(true);
+    expect(mi2.constraint).to.equal(true);
+    expect(mi2.type).to.equal('xs:string');
+    expect(mi2.path).to.equal('/greeting[1]');
+  });
 
-        const mi2 = model.modelItems[1];
-        expect(mi2.value).to.equal('Hello World!');
-        expect(mi2.readonly).to.equal(false);
-        expect(mi2.required).to.equal(false);
-        expect(mi2.relevant).to.equal(true);
-        expect(mi2.constraint).to.equal(true);
-        expect(mi2.type).to.equal('xs:string');
-        expect(mi2.path).to.equal('/greeting[1]');
+  it('creates a model when there is none', async () => {
+    const el = await fixtureSync(html`
+      <fx-form> </fx-form>
+    `);
 
+    // await elementUpdated(el);
+    const model = el.querySelector('fx-model');
+    expect(model).to.exist;
+    expect(model.instances).to.exist;
+    expect(model.instances.length).to.equal(1);
+  });
 
+  it('constructs an instance when there is none', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-group ref="outer">
+          <fx-output ref="inner1">inner1</fx-output>
+          <fx-output ref="inner2">inner2</fx-output>
+        </fx-group>
+      </fx-form>
+    `);
 
-    });
+    // let { detail } = await oneEvent(el, 'model-construct-done');
+    console.log('form  ', el);
 
-    it('creates a model when there is none', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                </fx-form>`)
-        );
-
-        // await elementUpdated(el);
-        const model = el.querySelector('fx-model');
-        expect(model).to.exist;
-        expect(model.instances).to.exist;
-        expect(model.instances.length).to.equal(1);
-    });
-
-    it('constructs an instance when there is none', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-group ref="outer">
-                        <fx-output ref="inner1">inner1</fx-output>
-                        <fx-output ref="inner2">inner2</fx-output>
-                    </fx-group>
-                </fx-form>`)
-        );
-
-        // let { detail } = await oneEvent(el, 'model-construct-done');
-        console.log('form  ', el);
-
-        const model = el.querySelector('fx-model');
-        console.log('model created ', model);
-        const inst = el.querySelector('fx-instance');
-        console.log('++++++++++++ inst ', inst);
-        // await elementUpdated(inst);
-        expect(inst).to.exist;
-        expect(inst.instanceData).to.exist;
-        const root = inst.instanceData.firstElementChild;
-        expect(root.nodeName).to.equal('data');
-        const outer = root.firstElementChild;
-        expect(outer.nodeName).to.equal('outer');
-        const inner = outer.firstElementChild;
-        expect(inner.nodeName).to.equal('inner1');
-        const inner2 = inner.nextSibling;
-        expect(inner2.nodeName).to.equal('inner2');
-
-    });
-
-
+    const model = el.querySelector('fx-model');
+    console.log('model created ', model);
+    const inst = el.querySelector('fx-instance');
+    console.log('++++++++++++ inst ', inst);
+    // await elementUpdated(inst);
+    expect(inst).to.exist;
+    expect(inst.instanceData).to.exist;
+    const root = inst.instanceData.firstElementChild;
+    expect(root.nodeName).to.equal('data');
+    const outer = root.firstElementChild;
+    expect(outer.nodeName).to.equal('outer');
+    const inner = outer.firstElementChild;
+    expect(inner.nodeName).to.equal('inner1');
+    const inner2 = inner.nextSibling;
+    expect(inner2.nodeName).to.equal('inner2');
+  });
 });

--- a/test/repeat.test.js
+++ b/test/repeat.test.js
@@ -1,5 +1,13 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 /*
 import '../src/fx-instance.js';
@@ -11,281 +19,245 @@ import '../src/fx-repeat.js';
 import '../src/fx-repeatitem.js';
 */
 import '../src/ui/fx-repeat.js';
-import {FxModel} from '../src/fx-model.js';
-
+import { FxModel } from '../src/fx-model.js';
 
 describe('repeat Tests', () => {
+  it('has initialized modelItems', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-    it('has initialized modelItems', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task">
-                            <fx-bind ref="." required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-                    <fx-group>
-                        <h1>todos</h1>
-                           
-                        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                            <template>
-                                <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                            </template>
-                        </fx-repeat>
-                           
-                        <fx-button label="append">
-                            <fx-append repeat="todos" ref="task"></fx-append>
-                        </fx-button>
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+          <fx-bind ref="task">
+            <fx-bind ref="." required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <h1>todos</h1>
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+          <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+            <template>
+              <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+            </template>
+          </fx-repeat>
 
-        const model = document.getElementById('record');
-        expect(model.modelItems.length).to.equal(6);
+          <fx-button label="append">
+            <fx-append repeat="todos" ref="task"></fx-append>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        // some modelItem checks
-        expect(model.modelItems[0].node.nodeName).to.equal('task');
-        expect(model.modelItems[0].value).to.equal('Pick up Milk');
-        expect(model.modelItems[0].required).to.equal(true);
+    const { detail } = await oneEvent(el, 'refresh-done');
 
-        expect(model.modelItems[1].node.nodeName).to.equal('task');
-        expect(model.modelItems[1].value).to.equal('Make tutorial part 1');
-        expect(model.modelItems[1].required).to.equal(true);
+    const model = document.getElementById('record');
+    expect(model.modelItems.length).to.equal(6);
 
-        expect(model.modelItems[2].node.nodeName).to.equal('complete'); //text node
-        expect(model.modelItems[2].node.nodeType).to.equal(2); //attribute node
-        expect(model.modelItems[2].value).to.equal('false');
+    // some modelItem checks
+    expect(model.modelItems[0].node.nodeName).to.equal('task');
+    expect(model.modelItems[0].value).to.equal('Pick up Milk');
+    expect(model.modelItems[0].required).to.equal(true);
 
-        expect(model.modelItems[3].node.nodeName).to.equal('complete'); //text node
-        expect(model.modelItems[3].node.nodeType).to.equal(2); //attribute node
-        expect(model.modelItems[3].value).to.equal('true');
+    expect(model.modelItems[1].node.nodeName).to.equal('task');
+    expect(model.modelItems[1].value).to.equal('Make tutorial part 1');
+    expect(model.modelItems[1].required).to.equal(true);
 
-        expect(model.modelItems[4].node.nodeName).to.equal('due'); //text node
-        expect(model.modelItems[4].node.nodeType).to.equal(2); //attribute node
-        expect(model.modelItems[4].value).to.equal('2019-02-04');
+    expect(model.modelItems[2].node.nodeName).to.equal('complete'); // text node
+    expect(model.modelItems[2].node.nodeType).to.equal(2); // attribute node
+    expect(model.modelItems[2].value).to.equal('false');
 
-        expect(model.modelItems[5].node.nodeName).to.equal('due'); //text node
-        expect(model.modelItems[5].node.nodeType).to.equal(2); //attribute node
-        expect(model.modelItems[5].value).to.equal('2019-01-04');
+    expect(model.modelItems[3].node.nodeName).to.equal('complete'); // text node
+    expect(model.modelItems[3].node.nodeType).to.equal(2); // attribute node
+    expect(model.modelItems[3].value).to.equal('true');
 
+    expect(model.modelItems[4].node.nodeName).to.equal('due'); // text node
+    expect(model.modelItems[4].node.nodeType).to.equal(2); // attribute node
+    expect(model.modelItems[4].value).to.equal('2019-02-04');
 
-    });
+    expect(model.modelItems[5].node.nodeName).to.equal('due'); // text node
+    expect(model.modelItems[5].node.nodeType).to.equal(2); // attribute node
+    expect(model.modelItems[5].value).to.equal('2019-01-04');
+  });
 
-    it('has initialized repeat with 2 repeat items', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-            
-                    <h1>todos</h1>
-                       
-                    <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                        <template>
-                            <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                        </template>
-                    </fx-repeat>
-                       
-                    <fx-button label="append">
-                        <fx-append repeat="todos" ref="task"></fx-append>
-                    </fx-button>
-            
-                </fx-form>
-            `)
-        );
+  it('has initialized repeat with 2 repeat items', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
 
-        const repeat =  document.getElementById('todos');
+        <h1>todos</h1>
 
-        const repeatNodes = repeat.nodeset;
-        console.log('items', repeatNodes);
+        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+          <template>
+            <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+          </template>
+        </fx-repeat>
 
-        expect(repeatNodes.length).to.equal(2);
+        <fx-button label="append">
+          <fx-append repeat="todos" ref="task"></fx-append>
+        </fx-button>
+      </fx-form>
+    `);
 
-        const items = repeat.querySelectorAll('fx-repeatitem');
-        // const items = document.querySelectorAll('fx-repeatitem');
-        // console.log('items', items);
-        expect(items.length).to.equal(2);
+    const { detail } = await oneEvent(el, 'refresh-done');
 
-        expect(repeat.getModel() instanceof FxModel).to.be.true;
+    const repeat = document.getElementById('todos');
 
-        let m = repeat.getModel().getModelItem(repeatNodes[0]);
-        console.log('repeatnode 1 ', m);
-        console.log('repeatnode 1 ', m.value);
+    const repeatNodes = repeat.nodeset;
+    console.log('items', repeatNodes);
 
-        expect(m.value).to.equal('Pick up Milk');
+    expect(repeatNodes.length).to.equal(2);
 
-        //check if control has correct value
-        const inputs = el.querySelectorAll('fx-input');
+    const items = repeat.querySelectorAll('fx-repeatitem');
+    // const items = document.querySelectorAll('fx-repeatitem');
+    // console.log('items', items);
+    expect(items.length).to.equal(2);
 
-        expect(inputs.length).to.equal(2);
+    expect(repeat.getModel() instanceof FxModel).to.be.true;
 
+    let m = repeat.getModel().getModelItem(repeatNodes[0]);
+    console.log('repeatnode 1 ', m);
+    console.log('repeatnode 1 ', m.value);
 
+    expect(m.value).to.equal('Pick up Milk');
 
-        m = repeat.getModel().getModelItem(repeatNodes[1]);
-        console.log('repeatnode 1 ', m);
-        console.log('repeatnode 1 ', m.value);
+    // check if control has correct value
+    const inputs = el.querySelectorAll('fx-input');
 
-        expect(m.value).to.equal('Make tutorial part 1');
+    expect(inputs.length).to.equal(2);
 
+    m = repeat.getModel().getModelItem(repeatNodes[1]);
+    console.log('repeatnode 1 ', m);
+    console.log('repeatnode 1 ', m.value);
 
+    expect(m.value).to.equal('Make tutorial part 1');
+  });
 
+  it('has initialized repeat with 2 repeat items within a outer group', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-    });
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <h1>todos</h1>
 
-    it('has initialized repeat with 2 repeat items within a outer group', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-                    <fx-group>
-                        <h1>todos</h1>
-                           
-                        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                            <template>
-                                <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                            </template>
-                        </fx-repeat>
-                           
-                        <fx-button label="append">
-                            <fx-append repeat="todos" ref="task"></fx-append>
-                        </fx-button>            
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+          <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+            <template>
+              <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+            </template>
+          </fx-repeat>
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+          <fx-button label="append">
+            <fx-append repeat="todos" ref="task"></fx-append>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        const repeat =  document.getElementById('todos');
+    const { detail } = await oneEvent(el, 'refresh-done');
 
-        const repeatNodes = repeat.nodeset;
-        console.log('items', repeatNodes);
+    const repeat = document.getElementById('todos');
 
-        expect(repeatNodes.length).to.equal(2);
+    const repeatNodes = repeat.nodeset;
+    console.log('items', repeatNodes);
 
-        const items = document.querySelectorAll('fx-repeatitem');
-        console.log('items', items);
-        expect(items.length).to.equal(2);
+    expect(repeatNodes.length).to.equal(2);
 
-        let m = repeat.getModel().getModelItem(repeatNodes[0]);
-        console.log('repeatnode 1 ', m);
-        console.log('repeatnode 1 ', m.value);
+    const items = document.querySelectorAll('fx-repeatitem');
+    console.log('items', items);
+    expect(items.length).to.equal(2);
 
-        expect(m.value).to.equal('Pick up Milk');
+    let m = repeat.getModel().getModelItem(repeatNodes[0]);
+    console.log('repeatnode 1 ', m);
+    console.log('repeatnode 1 ', m.value);
 
-        m = repeat.getModel().getModelItem(repeatNodes[1]);
-        console.log('repeatnode 1 ', m);
-        console.log('repeatnode 1 ', m.value);
+    expect(m.value).to.equal('Pick up Milk');
 
-        expect(m.value).to.equal('Make tutorial part 1');
+    m = repeat.getModel().getModelItem(repeatNodes[1]);
+    console.log('repeatnode 1 ', m);
+    console.log('repeatnode 1 ', m.value);
 
+    expect(m.value).to.equal('Make tutorial part 1');
+  });
+  it('has initialized repeat with 2 repeat items and proper UI state', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <h1>todos</h1>
 
+          <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+            <template>
+              <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+            </template>
+          </fx-repeat>
 
-    });
-    it('has initialized repeat with 2 repeat items and proper UI state', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-                    <fx-group>
-                        <h1>todos</h1>
-                           
-                        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                            <template>
-                                <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                            </template>
-                        </fx-repeat>
-                           
-                        <fx-button label="append">
-                            <fx-append repeat="todos" ref="task"></fx-append>
-                        </fx-button>            
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+          <fx-button label="append">
+            <fx-append repeat="todos" ref="task"></fx-append>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        // await elementUpdated(el);
-        let { detail } = await oneEvent(el, 'refresh-done');
+    // await elementUpdated(el);
+    const { detail } = await oneEvent(el, 'refresh-done');
 
-        const inputs = el.querySelectorAll('fx-repeatitem fx-input');
-        await elementUpdated(inputs);
+    const inputs = el.querySelectorAll('fx-repeatitem fx-input');
+    await elementUpdated(inputs);
 
-        expect(inputs.length).to.equal(2);
-        console.log('inputs ', inputs);
-        expect(inputs[0].getAttribute('value')).to.equal('Pick up Milk');
-        expect(inputs[0].value).to.equal('Pick up Milk');
-        expect(inputs[1].getAttribute('value')).to.equal('Make tutorial part 1');
-        expect(inputs[1].value).to.equal('Make tutorial part 1');
+    expect(inputs.length).to.equal(2);
+    console.log('inputs ', inputs);
+    expect(inputs[0].getAttribute('value')).to.equal('Pick up Milk');
+    expect(inputs[0].value).to.equal('Pick up Milk');
+    expect(inputs[1].getAttribute('value')).to.equal('Make tutorial part 1');
+    expect(inputs[1].value).to.equal('Make tutorial part 1');
+  });
 
-    });
-
-/*
+  /*
     it('handles a modelItem for the repeat itself', async () => {
         const el =  (
             await fixtureSync(html`
@@ -336,295 +308,272 @@ describe('repeat Tests', () => {
     });
 */
 
-    it('appends an item', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task" readonly="count(../task) < 3">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-                    <fx-group>
-                        <h1>todos</h1>
-                           
-                        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                            <template>
-                                <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                            </template>
-                        </fx-repeat>
-                           
-                        <fx-button label="append">
-                            <fx-append repeat="todos" ref="task"></fx-append>
-                        </fx-button>            
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+  it('appends an item', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-        await elementUpdated(el);
+          <fx-bind ref="task" readonly="count(../task) < 3">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <h1>todos</h1>
 
-        const button = el.querySelector('fx-button');
-        await elementUpdated(button);
+          <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+            <template>
+              <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+            </template>
+          </fx-repeat>
 
-        button.performActions();
+          <fx-button label="append">
+            <fx-append repeat="todos" ref="task"></fx-append>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        const repeat = el.querySelector('fx-repeat');
-        await elementUpdated(repeat);
+    await elementUpdated(el);
 
-        expect(repeat).to.exist;
-        const rItems = repeat.querySelectorAll('fx-repeatitem');
-        console.log('fx-repeat ', repeat);
-        expect(rItems.length).to.equal(3);
+    const button = el.querySelector('fx-button');
+    await elementUpdated(button);
 
-        // appended item should have repeatindex set
-        expect(rItems[2].hasAttribute('repeat-index')).to.be.true;
+    button.performActions();
 
-    });
+    const repeat = el.querySelector('fx-repeat');
+    await elementUpdated(repeat);
 
-    it('deletes an item', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task" readonly="count(../task) < 3">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-                    <fx-group>
-                        <h1>todos</h1>
-                           
-                        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                            <template>
-                                <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                                <fx-button label="delete">
-                                    <fx-delete ref="."></fx-delete>
-                                </fx-button>
-                            </template>
-                        </fx-repeat>
-                           
-                        <fx-button label="append">
-                            <fx-append repeat="todos" ref="task"></fx-append>
-                        </fx-button>            
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+    expect(repeat).to.exist;
+    const rItems = repeat.querySelectorAll('fx-repeatitem');
+    console.log('fx-repeat ', repeat);
+    expect(rItems.length).to.equal(3);
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+    // appended item should have repeatindex set
+    expect(rItems[2].hasAttribute('repeat-index')).to.be.true;
+  });
 
-        // hits the first button which is the delete button here
-        const button = el.querySelector('fx-button');
-        button.performActions();
+  it('deletes an item', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-        const repeat = el.querySelector('fx-repeat');
-        expect(repeat).to.exist;
+          <fx-bind ref="task" readonly="count(../task) < 3">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <h1>todos</h1>
 
-        const rItems = repeat.querySelectorAll('fx-repeatitem');
-        expect(rItems.length).to.equal(1);
-        expect(rItems[0].hasAttribute('repeat-index')).to.be.true;
-    });
+          <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+            <template>
+              <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+              <fx-button label="delete">
+                <fx-delete ref="."></fx-delete>
+              </fx-button>
+            </template>
+          </fx-repeat>
 
-    it('deletes an item and sets index', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-            
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                                <task complete="false" due="2019-01-05">third task</task>
-                                <task complete="false" due="2019-01-06">fourth task</task>
-                            </data>
-                        </fx-instance>
-            
-            
-                        <fx-bind ref="task" readonly="count(../task) < 3">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-            
-                    </fx-model>
-                    <fx-group>
-                        <h1>todos</h1>
-                           
-                        <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
-                            <template>
-                                <fx-input label="Task" ref="." id="task" type="text"></fx-input>
-                                <fx-button label="delete">
-                                    <fx-delete ref="."></fx-delete>
-                                </fx-button>
-                            </template>
-                        </fx-repeat>
-                           
-                        <fx-button label="append">
-                            <fx-append repeat="todos" ref="task"></fx-append>
-                        </fx-button>            
-                    </fx-group>
-                </fx-form>
-            `)
-        );
+          <fx-button label="append">
+            <fx-append repeat="todos" ref="task"></fx-append>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+    const { detail } = await oneEvent(el, 'refresh-done');
 
-        // hits the first button which is the delete button here
-        const buttons = el.querySelectorAll('fx-button');
-        buttons[2].performActions();
+    // hits the first button which is the delete button here
+    const button = el.querySelector('fx-button');
+    button.performActions();
 
-        const repeat = el.querySelector('fx-repeat');
-        expect(repeat).to.exist;
+    const repeat = el.querySelector('fx-repeat');
+    expect(repeat).to.exist;
 
-        const rItems = repeat.querySelectorAll('fx-repeatitem');
-        expect(rItems.length).to.equal(3);
-        expect(rItems[2].hasAttribute('repeat-index')).to.be.true;
-    });
+    const rItems = repeat.querySelectorAll('fx-repeatitem');
+    expect(rItems.length).to.equal(1);
+    expect(rItems[0].hasAttribute('repeat-index')).to.be.true;
+  });
 
-    it('handles indexes in simple repeat', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <task complete="false" due="2019-02-04">Pick up Milk</task>
-                                <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            </data>
-                        </fx-instance>
-        
-                        <fx-bind ref="task">
-                            <fx-bind ref="./text()" required="true()"></fx-bind>
-                            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
-                            <fx-bind ref="@due" type="xs:date"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-        
-                    <h1>todos</h1>
-        
-                    <fx-repeat focus-on-create="task" id="r-todos" ref="task">
-                        <template>
-                            <fx-input id="task" label="Task" ref="." type="text"></fx-input>
-                            <fx-input label="Due" ref="@due" type="date"></fx-input>
-                            <fx-input Label="Status" ref="@complete" type="checkbox"></fx-input>
-                            <fx-button label="delete">
-                                <fx-delete ref="."></fx-delete>
-                            </fx-button>
-                        </template>
-                    </fx-repeat>
-        
-                    <fx-button id="append" label="append">
-                        <fx-append ref="task" repeat="r-todos" clear="true"></fx-append>
-                    </fx-button>
-                </fx-form>
-            `)
-        );
+  it('deletes an item and sets index', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+              <task complete="false" due="2019-01-05">third task</task>
+              <task complete="false" due="2019-01-06">fourth task</task>
+            </data>
+          </fx-instance>
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+          <fx-bind ref="task" readonly="count(../task) < 3">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group>
+          <h1>todos</h1>
 
-        // hits the first button which is the delete button here
-        const append = el.querySelector('#append');
-        append.performActions();
+          <fx-repeat id="todos" ref="task" focus-on-create="task" id="r-todos">
+            <template>
+              <fx-input label="Task" ref="." id="task" type="text"></fx-input>
+              <fx-button label="delete">
+                <fx-delete ref="."></fx-delete>
+              </fx-button>
+            </template>
+          </fx-repeat>
 
-        const repeat = el.querySelector('#r-todos');
-        expect(repeat).to.exist;
+          <fx-button label="append">
+            <fx-append repeat="todos" ref="task"></fx-append>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        const rItems = repeat.querySelectorAll(':scope > fx-repeatitem');
-        expect(rItems.length).to.equal(3);
-        console.log('ritems ', rItems);
-        expect(rItems[2].hasAttribute('repeat-index')).to.be.true;
-    });
+    const { detail } = await oneEvent(el, 'refresh-done');
 
-    it('handles indexes in nested repeat', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model>
-                        <fx-instance>
-                            <data>
-                                <task text="Pick up Milk">
-                                    <task text="go to store"></task>
-                                </task>
-                            </data>
-                        </fx-instance>
-                
-                
-                        <fx-bind ref="task">
-                            <fx-bind ref="@text"></fx-bind>
-                
-                            <fx-bind ref="task">
-                                <fx-bind ref="@text"></fx-bind>
-                            </fx-bind>
-                        </fx-bind>
-                
-                    </fx-model>
-                        <h1>todos</h1>
-                        <fx-repeat focus-on-create="task" id="r-todos" ref="task">
-                            <template>
-                                <fx-control label="task" ref="@text"></fx-control>
-                                <fx-repeat id="r-subtask" ref="task">
-                                    <template>
-                                        <fx-control id="task" label="Task" ref="@text" type="text"></fx-control>
-                                        <fx-button label="delete">
-                                            <fx-delete ref="."></fx-delete>
-                                        </fx-button>
-                                    </template>
-                                </fx-repeat>
-                
-                                <fx-button label="add subtask">
-                                    <fx-append ref="task" repeat="r-subtask" clear="true"></fx-append>
-                                </fx-button>
-                                <fx-button label="delete">
-                                    <fx-delete ref="."></fx-delete>
-                                </fx-button>
-                            </template>
-                        </fx-repeat>
-                    
-                        <fx-button id="outerappend" label="add maintask">
-                            <fx-append ref="task" repeat="r-todos" clear="true"></fx-append>
-                        </fx-button>
-                </fx-form>            `)
-        );
+    // hits the first button which is the delete button here
+    const buttons = el.querySelectorAll('fx-button');
+    buttons[2].performActions();
 
-        let { detail } = await oneEvent(el, 'refresh-done');
+    const repeat = el.querySelector('fx-repeat');
+    expect(repeat).to.exist;
 
-        // hits the first button which is the delete button here
-        const append = el.querySelector('#outerappend');
-        append.performActions();
+    const rItems = repeat.querySelectorAll('fx-repeatitem');
+    expect(rItems.length).to.equal(3);
+    expect(rItems[2].hasAttribute('repeat-index')).to.be.true;
+  });
 
-        const repeat = el.querySelector('#r-todos');
-        expect(repeat).to.exist;
+  it('handles indexes in simple repeat', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+            </data>
+          </fx-instance>
 
-        const rItems = repeat.querySelectorAll(':scope > fx-repeatitem');
-        expect(rItems.length).to.equal(2);
-        console.log('ritems ', rItems);
-        expect(rItems[1].hasAttribute('repeat-index')).to.be.true;
-    });
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+            <fx-bind ref="@complete" type="xs:boolean"></fx-bind>
+            <fx-bind ref="@due" type="xs:date"></fx-bind>
+          </fx-bind>
+        </fx-model>
 
+        <h1>todos</h1>
 
+        <fx-repeat focus-on-create="task" id="r-todos" ref="task">
+          <template>
+            <fx-input id="task" label="Task" ref="." type="text"></fx-input>
+            <fx-input label="Due" ref="@due" type="date"></fx-input>
+            <fx-input Label="Status" ref="@complete" type="checkbox"></fx-input>
+            <fx-button label="delete">
+              <fx-delete ref="."></fx-delete>
+            </fx-button>
+          </template>
+        </fx-repeat>
+
+        <fx-button id="append" label="append">
+          <fx-append ref="task" repeat="r-todos" clear="true"></fx-append>
+        </fx-button>
+      </fx-form>
+    `);
+
+    const { detail } = await oneEvent(el, 'refresh-done');
+
+    // hits the first button which is the delete button here
+    const append = el.querySelector('#append');
+    append.performActions();
+
+    const repeat = el.querySelector('#r-todos');
+    expect(repeat).to.exist;
+
+    const rItems = repeat.querySelectorAll(':scope > fx-repeatitem');
+    expect(rItems.length).to.equal(3);
+    console.log('ritems ', rItems);
+    expect(rItems[2].hasAttribute('repeat-index')).to.be.true;
+  });
+
+  it('handles indexes in nested repeat', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model>
+          <fx-instance>
+            <data>
+              <task text="Pick up Milk">
+                <task text="go to store"></task>
+              </task>
+            </data>
+          </fx-instance>
+
+          <fx-bind ref="task">
+            <fx-bind ref="@text"></fx-bind>
+
+            <fx-bind ref="task">
+              <fx-bind ref="@text"></fx-bind>
+            </fx-bind>
+          </fx-bind>
+        </fx-model>
+        <h1>todos</h1>
+        <fx-repeat focus-on-create="task" id="r-todos" ref="task">
+          <template>
+            <fx-control label="task" ref="@text"></fx-control>
+            <fx-repeat id="r-subtask" ref="task">
+              <template>
+                <fx-control id="task" label="Task" ref="@text" type="text"></fx-control>
+                <fx-button label="delete">
+                  <fx-delete ref="."></fx-delete>
+                </fx-button>
+              </template>
+            </fx-repeat>
+
+            <fx-button label="add subtask">
+              <fx-append ref="task" repeat="r-subtask" clear="true"></fx-append>
+            </fx-button>
+            <fx-button label="delete">
+              <fx-delete ref="."></fx-delete>
+            </fx-button>
+          </template>
+        </fx-repeat>
+
+        <fx-button id="outerappend" label="add maintask">
+          <fx-append ref="task" repeat="r-todos" clear="true"></fx-append>
+        </fx-button>
+      </fx-form>
+    `);
+
+    const { detail } = await oneEvent(el, 'refresh-done');
+
+    // hits the first button which is the delete button here
+    const append = el.querySelector('#outerappend');
+    append.performActions();
+
+    const repeat = el.querySelector('#r-todos');
+    expect(repeat).to.exist;
+
+    const rItems = repeat.querySelectorAll(':scope > fx-repeatitem');
+    expect(rItems.length).to.equal(2);
+    console.log('ritems ', rItems);
+    expect(rItems[1].hasAttribute('repeat-index')).to.be.true;
+  });
 });

--- a/test/scoped-resolution.test.js
+++ b/test/scoped-resolution.test.js
@@ -1,238 +1,239 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../index.js';
 
 describe('scoped resolution tests', () => {
+  it('inscopeContext for child bind is equal to its parent', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <arm side="left">
+                <hand>
+                  <finger index="3">middle</finger>
+                </hand>
+              </arm>
+            </data>
+          </fx-instance>
+          <fx-bind id="parent" ref="arm">
+            <fx-bind id="child" ref="@side"></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-    it('inscopeContext for child bind is equal to its parent', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <arm side="left">
-                                    <hand>
-                                        <finger index="3">middle</finger>
-                                    </hand>
-                                </arm>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="parent" ref="arm">
-                            <fx-bind id="child" ref="@side"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>`)
-        );
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
+    expect(model.modelItems.length).to.equal(2);
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
-        expect(model.modelItems.length).to.equal(2);
+    const parent = el.querySelector('#parent');
+    const child = el.querySelector('#child');
 
-        const parent = el.querySelector('#parent');
-        const child = el.querySelector('#child');
+    const c = child._inScopeContext();
+    expect(child._inScopeContext()).to.equal(parent.nodeset);
+  });
 
+  it('inscopeContext for second child bind is equal to its parent', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <arm side="left">
+                <hand>
+                  <finger index="3">middle</finger>
+                </hand>
+              </arm>
+            </data>
+          </fx-instance>
+          <fx-bind id="parent" ref="arm">
+            <fx-bind id="child1" ref="@side"></fx-bind>
+            <fx-bind id="child2" ref="hand"></fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        const c = child._inScopeContext()
-        expect(child._inScopeContext()).to.equal(parent.nodeset);
-    });
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
+    expect(model.modelItems.length).to.equal(3);
 
-    it('inscopeContext for second child bind is equal to its parent', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <arm side="left">
-                                    <hand>
-                                        <finger index="3">middle</finger>
-                                    </hand>
-                                </arm>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="parent" ref="arm">
-                            <fx-bind id="child1" ref="@side"></fx-bind>
-                            <fx-bind id="child2" ref="hand"></fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>`)
-        );
+    const parent = el.querySelector('#parent');
+    const child = el.querySelector('#child2');
+    const c = child._inScopeContext();
+    expect(child._inScopeContext()).to.equal(parent.nodeset);
+  });
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
-        expect(model.modelItems.length).to.equal(3);
+  it('inscopeContext for subchild bind is equal to its parent', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <arm side="left">
+                <hand>
+                  <finger index="3">middle</finger>
+                </hand>
+              </arm>
+            </data>
+          </fx-instance>
+          <fx-bind id="parent" ref="arm">
+            <fx-bind id="child1" ref="@side"></fx-bind>
+            <fx-bind id="child2" ref="hand">
+              <fx-bind id="subchild" ref="finger"></fx-bind>
+            </fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        const parent = el.querySelector('#parent');
-        const child = el.querySelector('#child2');
-        const c = child._inScopeContext()
-        expect(child._inScopeContext()).to.equal(parent.nodeset);
-    });
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
+    expect(model.modelItems.length).to.equal(4);
 
-    it('inscopeContext for subchild bind is equal to its parent', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <arm side="left">
-                                    <hand>
-                                        <finger index="3">middle</finger>
-                                    </hand>
-                                </arm>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="parent" ref="arm">
-                            <fx-bind id="child1" ref="@side"></fx-bind>
-                            <fx-bind id="child2" ref="hand">
-                                <fx-bind id="subchild" ref="finger"></fx-bind>
-                            </fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>`)
-        );
+    const child = el.querySelector('#child2');
+    const subchild = el.querySelector('#subchild');
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
-        expect(model.modelItems.length).to.equal(4);
+    const c = subchild._inScopeContext();
+    expect(c).to.equal(child.nodeset);
+  });
 
-        const child = el.querySelector('#child2');
-        const subchild = el.querySelector('#subchild');
+  it('has 2 arms as nodeset', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <arm side="left">
+                <hand>
+                  <finger index="3">middle</finger>
+                </hand>
+              </arm>
+              <arm side="right">
+                <hand>
+                  <finger index="4">ring</finger>
+                </hand>
+              </arm>
+            </data>
+          </fx-instance>
+          <fx-bind id="parent" ref="arm">
+            <fx-bind id="child1" ref="@side"></fx-bind>
+            <fx-bind id="child2" ref="hand">
+              <fx-bind id="subchild" ref="finger"></fx-bind>
+            </fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        const c = subchild._inScopeContext()
-        expect(c).to.equal(child.nodeset);
-    });
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
+    // expect(model.modelItems.length).to.equal(8);
 
-    it('has 2 arms as nodeset', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <arm side="left">
-                                    <hand>
-                                        <finger index="3">middle</finger>
-                                    </hand>
-                                </arm>
-                                <arm side="right">
-                                    <hand>
-                                        <finger index="4">ring</finger>
-                                    </hand>
-                                </arm>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="parent" ref="arm">
-                            <fx-bind id="child1" ref="@side"></fx-bind>
-                            <fx-bind id="child2" ref="hand">
-                                <fx-bind id="subchild" ref="finger"></fx-bind>
-                            </fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>`)
-        );
+    const parent = el.querySelector('#parent');
+    expect(parent.nodeset.length).to.equal(2);
+  });
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
-        // expect(model.modelItems.length).to.equal(8);
+  it('has a 3 finger nodeset for the left arm', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <arm side="left">
+                <hand>
+                  <finger index="2">pointer</finger>
+                  <finger index="3">middle</finger>
+                  <finger index="4">ring</finger>
+                </hand>
+              </arm>
+              <arm side="right">
+                <hand>
+                  <finger index="4">ring</finger>
+                </hand>
+              </arm>
+            </data>
+          </fx-instance>
+          <fx-bind id="parent" ref="arm">
+            <fx-bind id="child1" ref="@side"></fx-bind>
+            <fx-bind id="child2" ref="hand">
+              <fx-bind id="subchild" ref="finger"></fx-bind>
+            </fx-bind>
+          </fx-bind>
+        </fx-model>
+      </fx-form>
+    `);
 
-        const parent = el.querySelector('#parent');
-        expect(parent.nodeset.length).to.equal(2);
-    });
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
+    expect(model.modelItems.length).to.equal(10);
 
-    it('has a 3 finger nodeset for the left arm', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <arm side="left">
-                                    <hand>
-                                        <finger index="2">pointer</finger>
-                                        <finger index="3">middle</finger>
-                                        <finger index="4">ring</finger>
-                                    </hand>
-                                </arm>
-                                <arm side="right">
-                                    <hand>
-                                        <finger index="4">ring</finger>
-                                    </hand>
-                                </arm>
-                            </data>
-                        </fx-instance>
-                        <fx-bind id="parent" ref="arm">
-                            <fx-bind id="child1" ref="@side"></fx-bind>
-                            <fx-bind id="child2" ref="hand">
-                                <fx-bind id="subchild" ref="finger"></fx-bind>
-                            </fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                </fx-form>`)
-        );
+    const parent = el.querySelector('#parent');
+    expect(parent.nodeset.length).to.equal(2);
+  });
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
-        expect(model.modelItems.length).to.equal(10);
+  it('correctly binds form controls', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <arm side="left">
+                <hand>
+                  <finger index="2">index</finger>
+                </hand>
+              </arm>
+              <arm side="right">
+                <hand>
+                  <finger index="3">middle</finger>
+                </hand>
+              </arm>
+            </data>
+          </fx-instance>
+          <fx-bind ref="arm">
+            <fx-bind ref="hand">
+              <fx-bind ref="finger">middle</fx-bind>
+            </fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-group ref="arm">
+          <h1>
+            hold up one finger!:
+            <fx-output ref=".[1]/hand/finger" id="output"></fx-output>
+          </h1>
+          <h2>
+            left or right?
+            <fx-output id="output2" ref="@side"></fx-output>
+            <fx-output id="output3" ref="/data/arm[2]/@side"></fx-output>
+          </h2>
+        </fx-group>
+      </fx-form>
+    `);
 
-        const parent = el.querySelector('#parent');
-        expect(parent.nodeset.length).to.equal(2);
-    });
+    const model = el.querySelector('fx-model');
 
-    it('correctly binds form controls', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="record">
-                        <fx-instance>
-                            <data>
-                                <arm side="left">
-                                    <hand>
-                                        <finger index="2">index</finger>
-                                    </hand>
-                                </arm>
-                                <arm side="right">
-                                    <hand>
-                                        <finger index="3">middle</finger>
-                                    </hand>
-                                </arm>
-                            </data>
-                        </fx-instance>
-                        <fx-bind ref="arm">
-                            <fx-bind ref="hand">
-                                <fx-bind ref="finger">middle</fx-bind>
-                            </fx-bind>
-                        </fx-bind>
-                    </fx-model>
-                    <fx-group ref="arm">
-                        <h1>hold up one finger!:
-                            <fx-output ref=".[1]/hand/finger" id="output"></fx-output>
-                        </h1>
-                        <h2>left or right?
-                            <fx-output id="output2" ref="@side"></fx-output>
-                            <fx-output id="output3" ref="/data/arm[2]/@side"></fx-output>
-                        </h2>
-                    </fx-group>
-                </fx-form>`)
-        );
+    const { detail } = await oneEvent(el, 'refresh-done');
+    console.log('model ', detail);
+    expect(model.modelItems.length).to.equal(8);
 
-        const model = el.querySelector('fx-model');
+    let out = el.querySelector('#output');
+    expect(out.modelItem.value).to.equal('index');
 
-        let { detail } = await oneEvent(el, 'refresh-done');
-        console.log('model ', detail);
-        expect(model.modelItems.length).to.equal(8);
+    out = el.querySelector('#output3');
+    expect(out.modelItem.value).to.equal('right');
+  });
 
-        let out = el.querySelector('#output');
-        expect(out.modelItem.value).to.equal('index');
-
-        out = el.querySelector('#output3');
-        expect(out.modelItem.value).to.equal('right');
-
-    });
-
-/*
+  /*
     it('dispatches a bind exception for non-existing ref', async () => {
         const el =  (
             await fixtureSync(html`
@@ -264,6 +265,4 @@ describe('scoped resolution tests', () => {
 
     });
 */
-
-
 });

--- a/test/setvalue.test.js
+++ b/test/setvalue.test.js
@@ -1,166 +1,163 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../index.js';
 import * as fx from 'fontoxpath';
 
 describe('setvalue tests', () => {
+  it('creates modelItem during refresh', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
 
-    it('creates modelItem during refresh', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                    </fx-model>
-                    
-                    <fx-group>
-                        <fx-output id="output" ref="greeting"></fx-output>
-                        <fx-button id="btn" label="say 'hello Universe'">
-                            <fx-setvalue ref="greeting" value="Hello Universe"></fx-setvalue>
-                        </fx-button>
-                    </fx-group>
-                </fx-form>`)
-        );
+        <fx-group>
+          <fx-output id="output" ref="greeting"></fx-output>
+          <fx-button id="btn" label="say 'hello Universe'">
+            <fx-setvalue ref="greeting" value="Hello Universe"></fx-setvalue>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
 
-        await elementUpdated(model);
-        expect(model.modelItems.length).to.equal(1);
+    await elementUpdated(model);
+    expect(model.modelItems.length).to.equal(1);
 
-        const inst = model.getDefaultInstance().getDefaultContext();
-        const xp = fx.evaluateXPath('greeting',inst,null,{});
-        console.log('plain eval: ', xp);
+    const inst = model.getDefaultInstance().getDefaultContext();
+    const xp = fx.evaluateXPath('greeting', inst, null, {});
+    console.log('plain eval: ', xp);
 
-        const btn = el.querySelector('#btn');
-        btn.performActions();
+    const btn = el.querySelector('#btn');
+    btn.performActions();
 
-        const out = el.querySelector('#output');
-        expect(out.modelItem.value).to.equal('Hello Universe');
+    const out = el.querySelector('#output');
+    expect(out.modelItem.value).to.equal('Hello Universe');
+  });
 
-    });
+  it('ignores setvalue actions with do not bind to a existing node', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
 
-    it('ignores setvalue actions with do not bind to a existing node', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                    </fx-model>
-                    
-                    <fx-group>
-                        <fx-output id="output" ref="greeting"></fx-output>
-                        <fx-button id="btn" label="say 'hello Universe'">
-                            <fx-setvalue ref="foo" value="Hello Universe"></fx-setvalue>
-                        </fx-button>
-                    </fx-group>
-                </fx-form>`)
-        );
+        <fx-group>
+          <fx-output id="output" ref="greeting"></fx-output>
+          <fx-button id="btn" label="say 'hello Universe'">
+            <fx-setvalue ref="foo" value="Hello Universe"></fx-setvalue>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
 
-        await elementUpdated(model);
-        expect(model.modelItems.length).to.equal(1);
+    await elementUpdated(model);
+    expect(model.modelItems.length).to.equal(1);
 
-        const inst = model.getDefaultInstance().getDefaultContext();
-        const xp = fx.evaluateXPath('greeting',inst,null,{});
-        console.log('plain eval: ', xp);
+    const inst = model.getDefaultInstance().getDefaultContext();
+    const xp = fx.evaluateXPath('greeting', inst, null, {});
+    console.log('plain eval: ', xp);
 
-        const btn = el.querySelector('#btn');
-        btn.performActions();
+    const btn = el.querySelector('#btn');
+    btn.performActions();
 
-        const out = el.querySelector('#output');
-        expect(out.modelItem.value).to.equal('Hello World!');
+    const out = el.querySelector('#output');
+    expect(out.modelItem.value).to.equal('Hello World!');
+  });
 
-    });
+  it('ignores uses element content if oresent', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
 
-    it('ignores uses element content if oresent', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                    </fx-model>
-                    
-                    <fx-group>
-                        <fx-output id="output" ref="greeting"></fx-output>
-                        <fx-button id="btn" label="say 'hello Universe'">
-                            <fx-setvalue ref="greeting">Hello Universe</fx-setvalue>
-                        </fx-button>
-                    </fx-group>
-                </fx-form>`)
-        );
+        <fx-group>
+          <fx-output id="output" ref="greeting"></fx-output>
+          <fx-button id="btn" label="say 'hello Universe'">
+            <fx-setvalue ref="greeting">Hello Universe</fx-setvalue>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
 
-        await elementUpdated(model);
-        expect(model.modelItems.length).to.equal(1);
+    await elementUpdated(model);
+    expect(model.modelItems.length).to.equal(1);
 
-        const inst = model.getDefaultInstance().getDefaultContext();
-        const xp = fx.evaluateXPath('greeting',inst,null,{});
-        console.log('plain eval: ', xp);
+    const inst = model.getDefaultInstance().getDefaultContext();
+    const xp = fx.evaluateXPath('greeting', inst, null, {});
+    console.log('plain eval: ', xp);
 
-        const btn = el.querySelector('#btn');
-        btn.performActions();
+    const btn = el.querySelector('#btn');
+    btn.performActions();
 
-        const out = el.querySelector('#output');
-        expect(out.modelItem.value).to.equal('Hello Universe');
+    const out = el.querySelector('#output');
+    expect(out.modelItem.value).to.equal('Hello Universe');
+  });
 
-    });
+  it('defaults to empty string if neither value nor textContent are present', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model id="model1">
+          <fx-instance>
+            <data>
+              <greeting>Hello World!</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
 
-    it('defaults to empty string if neither value nor textContent are present', async () => {
-        const el =  (
-            await fixtureSync(html`
-                <fx-form>
-                    <fx-model id="model1">
-                        <fx-instance>
-                            <data>
-                                <greeting>Hello World!</greeting>
-                            </data>
-                        </fx-instance>
-                    </fx-model>
-                    
-                    <fx-group>
-                        <fx-output id="output" ref="greeting"></fx-output>
-                        <fx-button id="btn" label="say 'hello Universe'">
-                            <fx-setvalue ref="greeting"></fx-setvalue>
-                        </fx-button>
-                    </fx-group>
-                </fx-form>`)
-        );
+        <fx-group>
+          <fx-output id="output" ref="greeting"></fx-output>
+          <fx-button id="btn" label="say 'hello Universe'">
+            <fx-setvalue ref="greeting"></fx-setvalue>
+          </fx-button>
+        </fx-group>
+      </fx-form>
+    `);
 
-        await elementUpdated(el);
-        const model = el.querySelector('fx-model');
+    await elementUpdated(el);
+    const model = el.querySelector('fx-model');
 
-        await elementUpdated(model);
-        expect(model.modelItems.length).to.equal(1);
+    await elementUpdated(model);
+    expect(model.modelItems.length).to.equal(1);
 
-        const inst = model.getDefaultInstance().getDefaultContext();
-        const xp = fx.evaluateXPath('greeting',inst,null,{});
-        console.log('plain eval: ', xp);
+    const inst = model.getDefaultInstance().getDefaultContext();
+    const xp = fx.evaluateXPath('greeting', inst, null, {});
+    console.log('plain eval: ', xp);
 
-        const btn = el.querySelector('#btn');
-        btn.performActions();
+    const btn = el.querySelector('#btn');
+    btn.performActions();
 
-        const out = el.querySelector('#output');
-        expect(out.modelItem.value).to.equal('');
-
-    });
-
-
+    const out = el.querySelector('#output');
+    expect(out.modelItem.value).to.equal('');
+  });
 });

--- a/test/template-expression.test.js
+++ b/test/template-expression.test.js
@@ -1,46 +1,45 @@
 /* eslint-disable no-unused-expressions */
-import { html, oneEvent, fixture, fixtureSync, expect, elementUpdated, defineCE } from '@open-wc/testing';
+import {
+  html,
+  oneEvent,
+  fixture,
+  fixtureSync,
+  expect,
+  elementUpdated,
+  defineCE,
+} from '@open-wc/testing';
 
 import '../index.js';
 
 describe('template expressions', () => {
+  it('detects template expressions', async () => {
+    const el = await fixtureSync(html`
+      <fx-form>
+        <fx-model>
+          <fx-instance>
+            <data>
+              <greeting>Hello Universe</greeting>
+            </data>
+          </fx-instance>
+        </fx-model>
 
-    it('detects template expressions', async () => {
-        const el =  (
-            await fixtureSync(html`
-            <fx-form>
-                <fx-model>
-                    <fx-instance>
-                        <data>
-                            <greeting>Hello Universe</greeting>
-                        </data>
-                    </fx-instance>
-                </fx-model>
+        <div class="static {greeting}">Greeting: {greeting} another {greeting}</div>
+        <fx-input ref="greeting" label="greeting"></fx-input>
+      </fx-form>
+    `);
 
-                <div class="static {greeting}">Greeting: {greeting} another {greeting}</div>
-                <fx-input ref="greeting" label="greeting"></fx-input>
+    const { detail } = await oneEvent(el, 'refresh-done');
+    expect(el.storedTemplateExpressions).to.exist;
+    expect(el.storedTemplateExpressions.length).to.equal(2);
+    expect(el.storedTemplateExpressions[0].expr).to.equal('static {greeting}');
+    expect(el.storedTemplateExpressions[1].expr).to.equal(
+      'Greeting: {greeting} another {greeting}',
+    );
 
+    const theDiv = el.querySelector('.static');
+    expect(theDiv).to.be.equal(el.storedTemplateExpressions[0].parent);
 
-            </fx-form>
-            `)
-        );
-
-
-        let { detail } = await oneEvent(el, 'refresh-done');
-        expect(el.storedTemplateExpressions).to.exist;
-        expect(el.storedTemplateExpressions.length).to.equal(2);
-        expect(el.storedTemplateExpressions[0].expr).to.equal('static {greeting}');
-        expect(el.storedTemplateExpressions[1].expr).to.equal('Greeting: {greeting} another {greeting}');
-
-        const theDiv = el.querySelector('.static');
-        expect(theDiv).to.be.equal(el.storedTemplateExpressions[0].parent);
-
-        expect(theDiv.getAttribute('class')).to.equal('static Hello Universe');
-        expect(theDiv.textContent).to.equal('Greeting: Hello Universe another Hello Universe');
-
-    });
-
-
-
-
+    expect(theDiv.getAttribute('class')).to.equal('static Hello Universe');
+    expect(theDiv.textContent).to.equal('Greeting: Hello Universe another Hello Universe');
+  });
 });


### PR DESCRIPTION
This PR ran prettier and ESslint a number of times until it stabilized.

TODO: Fix ESLint errors. There are many.

Many of them are console.logs that the ESlint config dislikes. A lot of unresolvable imports are coming from the demo, even some from an older demo folder. the other ones are some unused variables prefixed with `_`, some `++` and `--`, but those are not too concerning. Also a bunch of unused variables in tests. 

For me personally, because the code style differs a lot from my usual code style, applying prettier was the highest impact. Let's try to get this integrated asap, before anyone starts a big branch.