### PR TITLE
Implement the dependency graph without the need of explicit dependencies

### DIFF
--- a/demo/calc-order.html
+++ b/demo/calc-order.html
@@ -51,10 +51,10 @@
                             <result></result>
                         </data>
                     </fx-instance>
-                    <fx-bind ref="add" calculate="depends(../m2) + 5"></fx-bind>
-                    <fx-bind ref="m2" calculate="depends(../m1) * 2"></fx-bind>
+                    <fx-bind ref="add" calculate="../m2 + 5"></fx-bind>
+                    <fx-bind ref="m2" calculate="../m1 * 2"></fx-bind>
                     <!--
-                                        <fx-bind ref="result" calculate="depends(add)"></fx-bind>
+                                        <fx-bind ref="result" calculate="add"></fx-bind>
                     -->
 
                 </fx-model>

--- a/src/DependencyNotifyingDomFacade.js
+++ b/src/DependencyNotifyingDomFacade.js
@@ -1,0 +1,150 @@
+import {
+    getBucketsForNode
+} from 'fontoxpath';
+
+/**
+ * A DomFacade that will intercept any and all accesses to _nodes_ from an XPath. Basically the same
+ * as the `depends` function, but less explicit and will automatically be called for any node that
+ * will be touched in the XPath.
+ *
+ * Maybe some more granularity is better. Maybe only notify a node's attributes are touched?
+ */
+export class DependencyNotifyingDomFacade {
+
+    /**
+     * @param  {function(touchedNode: Node): void)} onNodeTouched A function what will be executed whenever a node is 'touched' by the XPath
+     */
+    constructor (onNodeTouched) {
+        this._onNodeTouched = onNodeTouched;
+    }
+
+    /**
+     * Get all attributes of this element.
+     * The bucket can be used to narrow down which attributes should be retrieved.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the attribute that will be used.
+     */
+    getAllAttributes(node, _bucket) {
+        return node.getAllAttributes();
+    }
+
+    /**
+     * Get the value of specified attribute of this element.
+     *
+     * @param  node -
+     * @param  attributeName -
+     */
+    getAttribute(node, attributeName) {
+        return node.getAttribute(attributeName);
+    }
+
+    /**
+     * Get all child nodes of this element.
+     * The bucket can be used to narrow down which child nodes should be retrieved.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the attribute that will be used.
+     */
+    getChildNodes(node, bucket) {
+        const matchingNodes = Array.from(node.childNodes).filter(childNode => getBucketsForNode(childNode).includes(bucket));
+        matchingNodes.forEach(matchingNode => this._onNodeTouched(matchingNode));
+        return matchingNodes;
+    }
+
+    /**
+     * Get the data of this element.
+     *
+     * @param  node -
+     */
+    getData(node) {
+        return node.data;
+    }
+
+    /**
+     * Get the first child of this element.
+     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the attribute that will be used.
+     */
+    getFirstChild(node, bucket) {
+        const matchingNode = Array.from(this.getChildNodes()).filter(childNode => getBucketsForNode(node).includes(bucket))[0];
+        if (matchingNode) {
+            this._onNodeTouched(matchingNode);
+            return matchingNode;
+        }
+        return null;
+    }
+
+    /**
+     * Get the last child of this element.
+     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the attribute that will be used.
+     */
+    getLastChild(node, bucket) {
+        const matchingNodes = node.getChildNodes().filter(childNode => getBucketsForNode(node).includes(bucket));
+        const matchingNode = matchingNode[matchingNodes.length - 1];
+        if (matchingNode) {
+            this._onNodeTouched(matchingNode);
+            return matchingNode;
+        }
+        return null;
+    }
+
+    /**
+     * Get the next sibling of this node
+     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the nextSibling that is requested.
+     */
+    getNextSibling(node, bucket) {
+        for (let nextSibling = node.nextSibling; nextSibling; nextSibling = nextSibling.nextSibling){
+            if (!getBucketsForNode(nextSibling).includes(bucket)) {
+                continue;
+            }
+
+            this._onNodeTouched(nextSibling);
+
+            return nextSibling;
+        }
+        return null;
+    }
+
+    /**
+     * Get the parent of this element.
+     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the attribute that will be used.
+     */
+    getParentNode(node, bucket) {
+        if (node.parentNode) {
+            this._onNodeTouched(node.parentNode);
+        }
+        return node.parentNode;
+    }
+
+    /**
+     * Get the previous sibling of this element.
+     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+     *
+     * @param  node -
+     * @param  bucket - The bucket that matches the attribute that will be used.
+     */
+    getPreviousSibling(node, bucket) {
+        for (let previousSibling = node.previousSibling; previousSibling; previousSibling = previousSibling.previousSibling){
+            if (!getBucketsForNode(previousSibling).includes(bucket)) {
+                continue;
+            }
+
+            this._onNodeTouched(previousSibling);
+
+            return previousSibling;
+        }
+        return null;
+    }
+}

--- a/src/DependencyNotifyingDomFacade.js
+++ b/src/DependencyNotifyingDomFacade.js
@@ -1,6 +1,4 @@
-import {
-    getBucketsForNode
-} from 'fontoxpath';
+import { getBucketsForNode } from 'fontoxpath';
 
 /**
  * A DomFacade that will intercept any and all accesses to _nodes_ from an XPath. Basically the same
@@ -10,141 +8,146 @@ import {
  * Maybe some more granularity is better. Maybe only notify a node's attributes are touched?
  */
 export class DependencyNotifyingDomFacade {
+  /**
+   * @param  {function(touchedNode: Node): void)} onNodeTouched A function what will be executed whenever a node is 'touched' by the XPath
+   */
+  constructor(onNodeTouched) {
+    this._onNodeTouched = onNodeTouched;
+  }
 
-    /**
-     * @param  {function(touchedNode: Node): void)} onNodeTouched A function what will be executed whenever a node is 'touched' by the XPath
-     */
-    constructor (onNodeTouched) {
-        this._onNodeTouched = onNodeTouched;
+  /**
+   * Get all attributes of this element.
+   * The bucket can be used to narrow down which attributes should be retrieved.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the attribute that will be used.
+   */
+  getAllAttributes(node, _bucket) {
+      return Array.from(node.attributes);
+  }
+
+  /**
+   * Get the value of specified attribute of this element.
+   *
+   * @param  node -
+   * @param  attributeName -
+   */
+  getAttribute(node, attributeName) {
+    return node.getAttribute(attributeName);
+  }
+
+  /**
+   * Get all child nodes of this element.
+   * The bucket can be used to narrow down which child nodes should be retrieved.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the attribute that will be used.
+   */
+  getChildNodes(node, bucket) {
+    const matchingNodes = Array.from(node.childNodes).filter(
+      childNode => !bucket || getBucketsForNode(childNode).includes(bucket),
+    );
+    return matchingNodes;
+  }
+
+  /**
+   * Get the data of this node.
+   *
+   * @param  node -
+   */
+	getData(node) {
+		if (node.nodeType === Node.ATTRIBUTE_NODE) {
+			this._onNodeTouched(node);
+			   return node.value;
+
+		}
+// Text node
+					this._onNodeTouched(node.parentNode);
+return node.data;
+  }
+
+  /**
+   * Get the first child of this element.
+   * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the attribute that will be used.
+   */
+  getFirstChild(node, bucket) {
+    const matchingNode = Array.from(this.getChildNodes()).filter(
+      childNode => !bucket || getBucketsForNode(childNode).includes(bucket),
+    )[0];
+    if (matchingNode) {
+      return matchingNode;
     }
+    return null;
+  }
 
-    /**
-     * Get all attributes of this element.
-     * The bucket can be used to narrow down which attributes should be retrieved.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the attribute that will be used.
-     */
-    getAllAttributes(node, _bucket) {
-        return node.getAllAttributes();
+  /**
+   * Get the last child of this element.
+   * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the attribute that will be used.
+   */
+  getLastChild(node, bucket) {
+    const matchingNodes = node
+      .getChildNodes()
+      .filter(childNode => !bucket || getBucketsForNode(childNode).includes(bucket));
+    const matchingNode = matchingNode[matchingNodes.length - 1];
+    if (matchingNode) {
+      return matchingNode;
     }
+    return null;
+  }
 
-    /**
-     * Get the value of specified attribute of this element.
-     *
-     * @param  node -
-     * @param  attributeName -
-     */
-    getAttribute(node, attributeName) {
-        return node.getAttribute(attributeName);
+  /**
+   * Get the next sibling of this node
+   * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the nextSibling that is requested.
+   */
+  getNextSibling(node, bucket) {
+    for (let { nextSibling } = node; nextSibling; nextSibling = nextSibling.nextSibling) {
+      if (!getBucketsForNode(nextSibling).includes(bucket)) {
+        continue;
+      }
+      return nextSibling;
     }
+    return null;
+  }
 
-    /**
-     * Get all child nodes of this element.
-     * The bucket can be used to narrow down which child nodes should be retrieved.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the attribute that will be used.
-     */
-    getChildNodes(node, bucket) {
-        const matchingNodes = Array.from(node.childNodes).filter(childNode => getBucketsForNode(childNode).includes(bucket));
-        matchingNodes.forEach(matchingNode => this._onNodeTouched(matchingNode));
-        return matchingNodes;
+  /**
+   * Get the parent of this element.
+   * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the attribute that will be used.
+   */
+  getParentNode(node, bucket) {
+    return node.parentNode;
+  }
+
+  /**
+   * Get the previous sibling of this element.
+   * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
+   *
+   * @param  node -
+   * @param  bucket - The bucket that matches the attribute that will be used.
+   */
+  getPreviousSibling(node, bucket) {
+    for (
+      let { previousSibling } = node;
+      previousSibling;
+      previousSibling = previousSibling.previousSibling
+    ) {
+      if (!getBucketsForNode(previousSibling).includes(bucket)) {
+        continue;
+      }
+
+      return previousSibling;
     }
-
-    /**
-     * Get the data of this element.
-     *
-     * @param  node -
-     */
-    getData(node) {
-        return node.data;
-    }
-
-    /**
-     * Get the first child of this element.
-     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the attribute that will be used.
-     */
-    getFirstChild(node, bucket) {
-        const matchingNode = Array.from(this.getChildNodes()).filter(childNode => getBucketsForNode(node).includes(bucket))[0];
-        if (matchingNode) {
-            this._onNodeTouched(matchingNode);
-            return matchingNode;
-        }
-        return null;
-    }
-
-    /**
-     * Get the last child of this element.
-     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the attribute that will be used.
-     */
-    getLastChild(node, bucket) {
-        const matchingNodes = node.getChildNodes().filter(childNode => getBucketsForNode(node).includes(bucket));
-        const matchingNode = matchingNode[matchingNodes.length - 1];
-        if (matchingNode) {
-            this._onNodeTouched(matchingNode);
-            return matchingNode;
-        }
-        return null;
-    }
-
-    /**
-     * Get the next sibling of this node
-     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the nextSibling that is requested.
-     */
-    getNextSibling(node, bucket) {
-        for (let nextSibling = node.nextSibling; nextSibling; nextSibling = nextSibling.nextSibling){
-            if (!getBucketsForNode(nextSibling).includes(bucket)) {
-                continue;
-            }
-
-            this._onNodeTouched(nextSibling);
-
-            return nextSibling;
-        }
-        return null;
-    }
-
-    /**
-     * Get the parent of this element.
-     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the attribute that will be used.
-     */
-    getParentNode(node, bucket) {
-        if (node.parentNode) {
-            this._onNodeTouched(node.parentNode);
-        }
-        return node.parentNode;
-    }
-
-    /**
-     * Get the previous sibling of this element.
-     * An implementation of IDomFacade is free to interpret the bucket to skip returning nodes that do not match the bucket, or use this information to its advantage.
-     *
-     * @param  node -
-     * @param  bucket - The bucket that matches the attribute that will be used.
-     */
-    getPreviousSibling(node, bucket) {
-        for (let previousSibling = node.previousSibling; previousSibling; previousSibling = previousSibling.previousSibling){
-            if (!getBucketsForNode(previousSibling).includes(bucket)) {
-                continue;
-            }
-
-            this._onNodeTouched(previousSibling);
-
-            return previousSibling;
-        }
-        return null;
-    }
+    return null;
+  }
 }

--- a/src/fx-bind.js
+++ b/src/fx-bind.js
@@ -2,6 +2,7 @@ import { ModelItem } from './modelitem.js';
 import { XPathUtil } from './xpath-util.js';
 import { foreElementMixin } from './ForeElementMixin.js';
 import { evaluateXPath, evaluateXPathToBoolean, evaluateXPathToNodes } from './xpath-evaluation.js';
+import {DependencyNotifyingDomFacade} from "./DependencyNotifyingDomFacade";
 
 /**
  * FxBind declaratively attaches constraints to nodes in the data (instances).
@@ -175,13 +176,18 @@ export class FxBind extends foreElementMixin(HTMLElement) {
 
   _buildBindGraph() {
     if (this.bindType === 'xml') {
+
+
+
       this.nodeset.forEach(node => {
         const path = XPathUtil.getPath(node);
+
+        const dependencies = [];
 
         const calculateRefs = this._getReferencesForProperty(this.calculate, node);
         if (calculateRefs.length !== 0) {
           this._addDependencies(calculateRefs, node, path, 'calculate');
-          this._addDependencies(calculateRefs, node, path, 'calculate');
+          // this._addDependencies(calculateRefs, node, path, 'calculate');
         } else if (this.calculate) {
           this.model.mainGraph.addNode(`${path}:calculate`, node);
         }
@@ -242,6 +248,7 @@ export class FxBind extends foreElementMixin(HTMLElement) {
           this.model.mainGraph.addNode(otherPath, other);
         }
         this.model.mainGraph.addDependency(`${path}:${property}`, otherPath);
+
       });
     } else {
       this.model.mainGraph.addNode(`${path}:${property}`, node);
@@ -343,7 +350,7 @@ export class FxBind extends foreElementMixin(HTMLElement) {
       }
       const inst = this.getModel().getInstance(this.instanceId);
       if (inst.type === 'xml') {
-        this.nodeset = evaluateXPathToNodes(this.ref, inscopeContext, formElement);
+        this.nodeset = evaluateXPathToNodes(this.ref, inscopeContext, this.getOwnerForm());
       } else {
         this.nodeset = this.ref;
       }

--- a/src/fx-bind.js
+++ b/src/fx-bind.js
@@ -1,8 +1,8 @@
-import { ModelItem } from './modelitem.js';
-import { XPathUtil } from './xpath-util.js';
+import { DependencyNotifyingDomFacade } from './DependencyNotifyingDomFacade.js';
 import { foreElementMixin } from './ForeElementMixin.js';
-import { evaluateXPath, evaluateXPathToBoolean, evaluateXPathToNodes } from './xpath-evaluation.js';
-import {DependencyNotifyingDomFacade} from "./DependencyNotifyingDomFacade";
+import { ModelItem } from './modelitem.js';
+import { evaluateXPathToBoolean, evaluateXPathToNodes, evaluateXPathToString } from './xpath-evaluation.js';
+import { XPathUtil } from './xpath-util.js';
 
 /**
  * FxBind declaratively attaches constraints to nodes in the data (instances).
@@ -176,20 +176,20 @@ export class FxBind extends foreElementMixin(HTMLElement) {
 
   _buildBindGraph() {
     if (this.bindType === 'xml') {
-
-
-
       this.nodeset.forEach(node => {
         const path = XPathUtil.getPath(node);
 
-        const dependencies = [];
+        if (this.calculate) {
+          this.model.mainGraph.addNode(`${path}:calculate`, node);
+          // Calculated values are a dependency of the model item.
+          // Make `model1` depend on `model1:calculate`
+          this.model.mainGraph.addNode(path, node);
+          this.model.mainGraph.addDependency(path, `${path}:calculate`);
+        }
 
         const calculateRefs = this._getReferencesForProperty(this.calculate, node);
         if (calculateRefs.length !== 0) {
           this._addDependencies(calculateRefs, node, path, 'calculate');
-          // this._addDependencies(calculateRefs, node, path, 'calculate');
-        } else if (this.calculate) {
-          this.model.mainGraph.addNode(`${path}:calculate`, node);
         }
 
         const readonlyRefs = this._getReferencesForProperty(this.readonly, node);
@@ -230,28 +230,31 @@ export class FxBind extends foreElementMixin(HTMLElement) {
     }
   }
 
+  /**
+   * Add the dependencies of this bind
+   *
+   * @param  {Node[]}  refs The nodes that are referenced by this bind. these need to be resolved before
+   * this bind can be resolved.
+   * @param  {Node}    node The start of the reference
+   * @param  {string}  path The path to the start of the reference
+   * @param  {string}  property The property with this dependency
+   */
   _addDependencies(refs, node, path, property) {
+    const nodeHash = `${path}:${property}`;
     if (refs.length !== 0) {
-      if (!this.model.mainGraph.hasNode(`${path}:${property}`)) {
-        // this.model.mainGraph.addNode(`${path}:${property}`, { node });
-        this.model.mainGraph.addNode(`${path}:${property}`, node);
+      if (!this.model.mainGraph.hasNode(nodeHash)) {
+        this.model.mainGraph.addNode(nodeHash, node);
       }
       refs.forEach(ref => {
-        // Note:
-        // This here runs XPath without setting a namespace resolve. Is this correct?
-
-        const other = evaluateXPath(ref, node, this.getOwnerForm());
-        const otherPath = XPathUtil.getPath(other);
+        const otherPath = XPathUtil.getPath(ref);
 
         if (!this.model.mainGraph.hasNode(otherPath)) {
-          // this.model.mainGraph.addNode(otherPath,{node:other});
-          this.model.mainGraph.addNode(otherPath, other);
+          this.model.mainGraph.addNode(otherPath, ref);
         }
-        this.model.mainGraph.addDependency(`${path}:${property}`, otherPath);
-
+        this.model.mainGraph.addDependency(nodeHash, otherPath);
       });
     } else {
-      this.model.mainGraph.addNode(`${path}:${property}`, node);
+      this.model.mainGraph.addNode(nodeHash, node);
     }
   }
 
@@ -499,25 +502,22 @@ export class FxBind extends foreElementMixin(HTMLElement) {
     this.getModel().registerModelItem(newItem);
   }
 
-  // _getReferencesForProperty(propertyExpr, node) {
-
-  // eslint-disable-next-line class-methods-use-this
+  /**
+   * Get the nodes that are referred by the given XPath expression
+   *
+   * @param  {string}  propertyExpr  The XPath to get the referenced nodes from
+   *
+   * @return {Node[]}  The nodes that are referenced by the XPath
+   */
   _getReferencesForProperty(propertyExpr) {
     if (propertyExpr) {
-      // const ast = fx.parseScript(propertyExpr, {}, new DOMParser().parseFromString('<nothing/>', 'text/xml'));
-      // console.log(`AST for ${propertyExpr}`, ast.innerHTML);p
-
-      const pieces = propertyExpr.split('depends');
-      const dependants = [];
-      pieces.forEach(step => {
-        // console.log('step ', step);
-        if (step.trim().startsWith('(')) {
-          const name = step.substring(1, step.indexOf(')'));
-          dependants.push(name);
-        }
+      const touchedNodes = new Set();
+      const domFacade = new DependencyNotifyingDomFacade(otherNode => touchedNodes.add(otherNode));
+      this.nodeset.forEach(node => {
+          evaluateXPathToString(propertyExpr, node, null, domFacade);
       });
-      // console.log(`dependants of ${propertyExpr} `, dependants);
-      return dependants;
+
+      return Array.from(touchedNodes.values());
     }
     return [];
   }

--- a/src/fx-model.js
+++ b/src/fx-model.js
@@ -163,7 +163,7 @@ export class FxModel extends HTMLElement {
       const modelItem = this.getModelItem(node);
       // console.log('modelitem ', modelItem);
 
-      if (modelItem && path.indexOf(':')) {
+      if (modelItem && path.includes(':')) {
         const property = path.split(':')[1];
         if (property) {
           if (property === 'calculate') {

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -228,16 +228,18 @@ export function evaluateXPathToBoolean(xpath, contextNode, formElement) {
 /**
  * Evaluate an XPath to a string
  *
- * @param  {string} xpath  The XPath to run
- * @param  {Node} contextNode The start of the XPath
- * @param  {Node} formElement  The form element associated to the XPath
+ * @param  {string}     xpath             The XPath to run
+ * @param  {Node}       contextNode       The start of the XPath
+ * @param  {Node}       formElement       The form element associated to the XPath
+ * @param  {DomFacade}  [domFacade=null]  A DomFacade is used in bindings to intercept DOM
+ * access. This is used to determine dependencies between bind elements.
  * @return {string}
  */
-export function evaluateXPathToString(xpath, contextNode, formElement) {
+export function evaluateXPathToString(xpath, contextNode, formElement, domFacade = null) {
   return fxEvaluateXPathToString(
     xpath,
     contextNode,
-    null,
+    domFacade,
     {},
     {
       currentContext: { formElement },

--- a/test/bind.test.js
+++ b/test/bind.test.js
@@ -58,7 +58,7 @@ describe('bind Tests', () => {
                             <fx-bind id="b-type" ref="@type"></fx-bind>
                         </fx-bind>
                     </fx-model>
-                </fx-form>               
+                </fx-form>
             `)
         );
 
@@ -254,7 +254,7 @@ describe('bind Tests', () => {
                     </fx-model>
                     <fx-output id="output" ref="greet"></fx-output>
 
-                </fx-form>               
+                </fx-form>
             `)
         );
 
@@ -337,6 +337,91 @@ describe('bind Tests', () => {
     expect(out2.ref).to.equal('greeting/@type');
     expect(out2.value).to.equal('message');
   });
+
+	it('can resolve calculates in bind in the correct order: nodes', async () => {
+    const el = await fixture(html`
+            <fx-form>
+
+                <fx-model id="model1">
+                    <fx-instance>
+                        <data>
+                            <m1>3</m1>
+                            <m2>0</m2>
+                            <add>0</add>
+                            <result></result>
+                        </data>
+                    </fx-instance>
+                    <fx-bind ref="add" calculate="../m2 + 5"></fx-bind>
+                    <fx-bind ref="m2" calculate="../m1 * 2"></fx-bind>
+                </fx-model>
+                <fx-group>
+                  <fx-output id="output" ref="add"></fx-output>
+                </fx-group>
+            </fx-form>
+
+    `);
+
+		await elementUpdated(el);
+
+		const output = el.querySelector('#output');
+		expect(output.value).to.equal('11');
+  });
+
+		it('can resolve calculates in bind in the correct order: attributes', async () => {
+    const el = await fixture(html`
+            <fx-form>
+
+                <fx-model id="model1">
+                    <fx-instance>
+                        <data>
+                            <m1 val="3"></m1>
+                            <m2 val="0"></m2>
+                            <add val="0"></add>
+                            <result></result>
+                        </data>
+                    </fx-instance>
+                    <fx-bind ref="add" calculate="../m2/@val + 5"></fx-bind>
+                    <fx-bind ref="m2/@val" calculate="../../m1/@val * 2"></fx-bind>
+                </fx-model>
+                <fx-group>
+                  <fx-output id="output" ref="add"></fx-output>
+                </fx-group>
+            </fx-form>
+
+    `);
+
+		await elementUpdated(el);
+
+		const output = el.querySelector('#output');
+		expect(output.value).to.equal('11');
+		});
+
+			it('does not explode on recursive dependencies', async () => {
+    const el = await fixture(html`
+            <fx-form>
+
+                <fx-model id="model1">
+                        <data>
+                            <m1>3</m1>
+                            <m2>0</m2>
+                        </data>
+                    </fx-instance>
+                    <fx-bind ref="m1" calculate="../m2 + 5"></fx-bind>
+                    <fx-bind ref="m2" calculate="../m1 * 2"></fx-bind>
+                </fx-model>
+                <fx-group>
+                  <fx-output id="output" ref="add"></fx-output>
+                </fx-group>
+            </fx-form>
+
+    `);
+
+		await elementUpdated(el);
+
+		const output = el.querySelector('#output');
+		expect(output.value).to.equal('');
+  });
+
 
   it('fails using camelcase node names', async () => {
     const el = await fixtureSync(html`


### PR DESCRIPTION
Just run XPath and see what they touch. This should work very scalable. This is simpler then going try to reimplement XPath to try to interpret ASTs.