### PR TITLE
Add some intricate (working) JSON examples

### DIFF
--- a/demo/hello-json.html
+++ b/demo/hello-json.html
@@ -31,7 +31,7 @@
     <fx-message event="refresh-done">refresh has been done</fx-message>
 
     <fx-model id="model1">
-        <fx-instance type="json">
+        <fx-instance id="instance1" type="json">
             {
                 "automobiles": [
                     {
@@ -72,18 +72,27 @@
         -->
     </fx-model>
     <fx-group>
-
-
         <h1>
-            Your favorite car:
-<!--            {?1?automobiles[1]?maker[1]}-->
-            {parse-json(instance())}
+            The car maker of the day:
+            {?automobiles?*[current-date() => day-from-date() mod 5]?maker}
         </h1>
+
+		<h2>Repeating over JSON</h2>
+
+		<ul>
+		  <fx-repeat ref="?automobiles">
+			<template>
+			  <li>
+				<strong>Maker:</strong> {?maker} <strong>Model:</strong> {?model} <i>{let $maker := ?maker =>trace() return if(instance('instance1')?motorcycles?*[?maker = $maker]=> exists()) then "Also makes motorcycles" else "Makes no motorcycles"}</i>
+			  </li>
+			</template>
+		  </fx-repeat>
+		</ul>
 
 <!--
         <fx-trigger>
             <button>set year</button>
-            <fx-setvalue ref="?automobiles[?maker = 'Honda' and ?model = 'Accord']?year" value="2020"></fx-setvalue>
+            <fx-setvalue ref="?automobiles?*[?maker = 'Honda' and ?model = 'Accord']?year" value="2020"></fx-setvalue>
         </fx-trigger>
 -->
     </fx-group>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@polymer/paper-input": "^3.2.1",
         "@vaadin/vaadin-notification": "^1.4.0",
         "@vanillawc/wc-codemirror": "^1.9.1",
-        "fontoxpath": "^3.17.4"
+        "fontoxpath": "^3.18.1"
       },
       "devDependencies": {
         "@0xcda7a/empathy": "0.0.9",
@@ -5417,7 +5417,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6908,9 +6907,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.1.tgz",
       "integrity": "sha512-/y7M2ULg06JOXmMpPzhTeQroJSchy8lX8q6qrjqil0jmLz6ejCWbQzVnWTsdmMQRhfU0QcwtiW8iZlmrGXWV4g==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.1"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -8001,9 +7997,9 @@
       }
     },
     "node_modules/fontoxpath": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.17.4.tgz",
-      "integrity": "sha512-BDtf/sKM0M1/NfHPrRZwjpddykZkYWsoVawb7AMgaeX/v7daticV8Nr/KAx62++y1cIg4/j6j6f9/f7QZVVzgg==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.18.1.tgz",
+      "integrity": "sha512-UReXnsJ3K/dIKNmBT7U8+dFMYMGgI2RURlFPwncVqEmEfE5HJI9SPDvFDN72YJODSzhETDy5yCXjUMYbyv5Pmw==",
       "dependencies": {
         "xspattern": "^2.0.0"
       }
@@ -9873,9 +9869,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -11479,7 +11472,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -12710,9 +12702,6 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
       "dev": true,
-      "dependencies": {
-        "clipboard": "^2.0.0"
-      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }
@@ -23201,9 +23190,9 @@
       "dev": true
     },
     "fontoxpath": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.17.4.tgz",
-      "integrity": "sha512-BDtf/sKM0M1/NfHPrRZwjpddykZkYWsoVawb7AMgaeX/v7daticV8Nr/KAx62++y1cIg4/j6j6f9/f7QZVVzgg==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.18.1.tgz",
+      "integrity": "sha512-UReXnsJ3K/dIKNmBT7U8+dFMYMGgI2RURlFPwncVqEmEfE5HJI9SPDvFDN72YJODSzhETDy5yCXjUMYbyv5Pmw==",
       "requires": {
         "xspattern": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@polymer/paper-input": "^3.2.1",
     "@vaadin/vaadin-notification": "^1.4.0",
     "@vanillawc/wc-codemirror": "^1.9.1",
-    "fontoxpath": "^3.17.4"
+    "fontoxpath": "^3.18.1"
   },
   "devDependencies": {
     "@0xcda7a/empathy": "0.0.9",

--- a/src/ui/fx-repeat.js
+++ b/src/ui/fx-repeat.js
@@ -177,8 +177,8 @@ export class FxRepeat extends foreElementMixin(HTMLElement) {
         return;
       }
 
-      if (Array.isArray(seq) && seq.every(item => 'nodeType' in item)) {
-        // multiple Nodes
+      if (Array.isArray(seq) && seq.every(item => typeof item === 'object')) {
+        // multiple Nodes or maps
         this.nodeset = seq;
         return;
       }

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -72,7 +72,7 @@ function buildTree(tree, data) {
         // }
       });
     }
-  } /*else if(data.nodeType === Node.ATTRIBUTE_NODE){
+  } /* else if(data.nodeType === Node.ATTRIBUTE_NODE){
         //create span for now
         // const span = document.createElement('span');
         // span.style.background = 'grey';
@@ -81,7 +81,7 @@ function buildTree(tree, data) {
         tree.setAttribute(data.nodeName,data.value);
     }else {
         tree.textContent = data;
-    }*/
+    } */
 
   return tree;
 }
@@ -136,17 +136,19 @@ const instance = (dynamicContext, string) => {
   return null;
 };
 
+// Note that this is not to spec. The spec enforces elements to be returned from the
+// instance. However, we allow instances to actually be JSON!
 registerCustomXPathFunction(
   { namespaceURI: XFORMS_NAMESPACE_URI, localName: 'instance' },
   [],
-  'element()?',
+  'item()?',
   domFacade => instance(domFacade, null),
 );
 
 registerCustomXPathFunction(
   { namespaceURI: XFORMS_NAMESPACE_URI, localName: 'instance' },
   ['xs:string?'],
-  'element()?',
+  'item()?',
   instance,
 );
 
@@ -346,6 +348,7 @@ export function evaluateXPathToString(xpath, contextNode, formElement, domFacade
     contextNode,
     domFacade,
     {},
+
     {
       currentContext: { formElement },
       functionNameResolver,


### PR DESCRIPTION
The main bug was in FontoXPath. The upgrade fixes those.
I also made `fx:instance()` return `item()?` instead of `element()?` since we are allowing JSON to be more usable.

The example also includes looping over maps and arrays, which is extremely useful imho.

TODO: Editing JSON. I have some ideas w.r.t. keeping instance equality intact over XPath queries. Doing so may make it very easy to set values: setting those values in a deep map will update it in the JSON structure. 