### PR TITLE
Fix tests and defaulting happening in fx-insert

### DIFF
--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -1,8 +1,9 @@
 import {
   evaluateXPath as fxEvaluateXPath,
+  evaluateXPathToBoolean as fxEvaluateXPathToBoolean,
   evaluateXPathToFirstNode as fxEvaluateXPathToFirstNode,
   evaluateXPathToNodes as fxEvaluateXPathToNodes,
-  evaluateXPathToBoolean as fxEvaluateXPathToBoolean,
+  evaluateXPathToNumber as fxEvaluateXPathToNumber,
   evaluateXPathToString as fxEvaluateXPathToString,
   registerCustomXPathFunction,
   registerXQueryModule,
@@ -107,12 +108,11 @@ registerCustomXPathFunction(
       if (logtree) {
         logtree.parentNode.removeChild(logtree);
       }
-        form.appendChild(buildTree(tree, instance.getDefaultContext()));
+      form.appendChild(buildTree(tree, instance.getDefaultContext()));
     }
     return null;
   },
 );
-
 
 const instance = (dynamicContext, string) => {
   // Spec: https://www.w3.org/TR/xforms-xpath/#The_XForms_Function_Library#The_instance.28.29_Function
@@ -138,21 +138,19 @@ const instance = (dynamicContext, string) => {
 };
 
 registerCustomXPathFunction(
-    { namespaceURI: XFORMS_NAMESPACE_URI, localName: 'index' },
-    ['xs:string?'],
-    'xs:integer?',
-    (dynamicContext, string) => {
-        const { formElement } = dynamicContext.currentContext;
-        const repeat = string
-            ? formElement.querySelector(`fx-repeat[id=${string}]`)
-            : null;
+  { namespaceURI: XFORMS_NAMESPACE_URI, localName: 'index' },
+  ['xs:string?'],
+  'xs:integer?',
+  (dynamicContext, string) => {
+    const { formElement } = dynamicContext.currentContext;
+    const repeat = string ? formElement.querySelector(`fx-repeat[id=${string}]`) : null;
 
-        // const def = instance.getInstanceData();
-        if (repeat) {
-            return repeat.getAttribute('index');
-        }
-        return Number(1);
+    // const def = instance.getInstanceData();
+    if (repeat) {
+      return repeat.getAttribute('index');
     }
+    return Number(1);
+  },
 );
 
 // Note that this is not to spec. The spec enforces elements to be returned from the
@@ -379,6 +377,34 @@ export function evaluateXPathToBoolean(xpath, contextNode, formElement) {
  */
 export function evaluateXPathToString(xpath, contextNode, formElement, domFacade = null) {
   return fxEvaluateXPathToString(
+    xpath,
+    contextNode,
+    domFacade,
+    {},
+
+    {
+      currentContext: { formElement },
+      functionNameResolver,
+      moduleImports: {
+        xf: XFORMS_NAMESPACE_URI,
+      },
+      namespaceResolver,
+    },
+  );
+}
+
+/**
+ * Evaluate an XPath to a number
+ *
+ * @param  {string}     xpath             The XPath to run
+ * @param  {Node}       contextNode       The start of the XPath
+ * @param  {Node}       formElement       The form element associated to the XPath
+ * @param  {DomFacade}  [domFacade=null]  A DomFacade is used in bindings to intercept DOM
+ * access. This is used to determine dependencies between bind elements.
+ * @return {string}
+ */
+export function evaluateXPathToNumber(xpath, contextNode, formElement, domFacade = null) {
+  return fxEvaluateXPathToNumber(
     xpath,
     contextNode,
     domFacade,

--- a/test/insert.test.js
+++ b/test/insert.test.js
@@ -5,29 +5,28 @@ import * as fx from 'fontoxpath';
 import '../src/fx-instance.js';
 
 describe('insert Tests', () => {
-  it('inserts at end by default', async () => {
+  it('inserts at end by default: into empty sequence', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                        </data>
-                    </fx-instance>
-                    <fx-bind ref="task">
-                        <fx-bind ref="./text()" required="true()"></fx-bind>
-                    </fx-bind>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data> </data>
+          </fx-instance>
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert at end</button>
-                    <fx-insert ref="task"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert at end</button>
+          <fx-insert ref="task"></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -40,32 +39,32 @@ describe('insert Tests', () => {
     expect(tasks.length).to.equal(0);
   });
 
-  it('inserts at end by default', async () => {
+  it('inserts at end by default: into filled sequence', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task complete="false" due="2019-02-04">Pick up Milk</task>
-                            <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            <task complete="true" due="2020-01-05">Make tutorial part 2</task>
-                        </data>
-                    </fx-instance>
-                    <fx-bind ref="task">
-                        <fx-bind ref="./text()" required="true()"></fx-bind>
-                    </fx-bind>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+              <task complete="true" due="2020-01-05">Make tutorial part 2</task>
+            </data>
+          </fx-instance>
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert at end</button>
-                    <fx-insert ref="task"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert at end</button>
+          <fx-insert ref="task" keep-values="true"></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -89,36 +88,34 @@ describe('insert Tests', () => {
     expect(tasks[2].textContent).to.equal(tasks[3].textContent);
     expect(tasks[2].getAttribute('complete')).to.equal(tasks[3].getAttribute('complete'));
     expect(tasks[2].getAttribute('due')).to.equal(tasks[3].getAttribute('due'));
-
-
   });
 
   it('inserts as first with position=before', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task complete="false" due="2019-02-04">Pick up Milk</task>
-                            <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            <task complete="true" due="2020-01-05">Make tutorial part 2</task>
-                        </data>
-                    </fx-instance>
-                    <fx-bind ref="task">
-                        <fx-bind ref="./text()" required="true()"></fx-bind>
-                    </fx-bind>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+              <task complete="true" due="2020-01-05">Make tutorial part 2</task>
+            </data>
+          </fx-instance>
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert as first</button>
-                    <fx-insert ref="task" position="before" at="1"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert as first</button>
+          <fx-insert ref="task" position="before" at="1" keep-values="true"></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -138,36 +135,34 @@ describe('insert Tests', () => {
     expect(tasks[0].textContent).to.equal(tasks[3].textContent);
     expect(tasks[0].getAttribute('complete')).to.equal(tasks[3].getAttribute('complete'));
     expect(tasks[0].getAttribute('due')).to.equal(tasks[3].getAttribute('due'));
-
-
   });
 
   it('inserts after first with position=after', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task complete="false" due="2019-02-04">Pick up Milk</task>
-                            <task complete="true" due="2019-01-04">Make tutorial part 1</task>
-                            <task complete="true" due="2020-01-05">Make tutorial part 2</task>
-                        </data>
-                    </fx-instance>
-                    <fx-bind ref="task">
-                        <fx-bind ref="./text()" required="true()"></fx-bind>
-                    </fx-bind>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task complete="false" due="2019-02-04">Pick up Milk</task>
+              <task complete="true" due="2019-01-04">Make tutorial part 1</task>
+              <task complete="true" due="2020-01-05">Make tutorial part 2</task>
+            </data>
+          </fx-instance>
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert after first</button>
-                    <fx-insert ref="task" position="after" at="1"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert after first</button>
+          <fx-insert ref="task" position="after" at="1" keep-values="true"></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -187,39 +182,38 @@ describe('insert Tests', () => {
     expect(tasks[1].textContent).to.equal(tasks[3].textContent);
     expect(tasks[1].getAttribute('complete')).to.equal(tasks[3].getAttribute('complete'));
     expect(tasks[1].getAttribute('due')).to.equal(tasks[3].getAttribute('due'));
-
   });
 
   it('inserts from origin', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task></task>
-                        </data>
-                    </fx-instance>
-                     <fx-instance id="templ">
-                        <data>
-                            <task> </task>
-                            <foo> </foo>
-                        </data>
-                    </fx-instance>
-                    <fx-bind ref="task">
-                        <fx-bind ref="./text()" required="true()"></fx-bind>
-                    </fx-bind>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task></task>
+            </data>
+          </fx-instance>
+          <fx-instance id="templ">
+            <data>
+              <task> </task>
+              <foo> </foo>
+            </data>
+          </fx-instance>
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert at end</button>
-                    <fx-insert ref="instance('default')" origin="instance('tmpl')/foo"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert at end</button>
+          <fx-insert ref="instance('default')" origin="instance('templ')/foo"></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -234,28 +228,28 @@ describe('insert Tests', () => {
 
   it('inserts when targetSequence is a single item', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task></task>
-                        </data>
-                    </fx-instance>
-                    <fx-bind ref="task">
-                        <fx-bind ref="./text()" required="true()"></fx-bind>
-                    </fx-bind>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" id="r-todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task></task>
+            </data>
+          </fx-instance>
+          <fx-bind ref="task">
+            <fx-bind ref="./text()" required="true()"></fx-bind>
+          </fx-bind>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" id="r-todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert at end</button>
-                    <fx-insert ref="task"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert at end</button>
+          <fx-insert ref="task"></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -270,27 +264,27 @@ describe('insert Tests', () => {
 
   it('inserts after current repeatitem', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task>one</task>
-                            <task>two</task>
-                            <task>three</task>
-                        </data>
-                    </fx-instance>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task>one</task>
+              <task>two</task>
+              <task>three</task>
+            </data>
+          </fx-instance>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert at end</button>
-                    <fx-insert ref="task" at="index('todos')"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert at end</button>
+          <fx-insert ref="task" at="index('todos')" keep-values="true"> </fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
@@ -301,33 +295,38 @@ describe('insert Tests', () => {
 
     expect(tasks.length).to.equal(4);
     expect(tasks[1].textContent).to.equal('three');
-
   });
 
   it('inserts before current repeatitem', async () => {
     const el = await fixtureSync(html`
-            <fx-fore>
-                <fx-model id="record">
-                    <fx-instance>
-                        <data>
-                            <task>one</task>
-                            <task>two</task>
-                            <task>three</task>
-                        </data>
-                    </fx-instance>
-                </fx-model>
-                <fx-repeat focus-on-create="task" id="todos" ref="task">
-                    <template>
-                        <fx-control id="task" ref="."></fx-control>
-                    </template>
-                </fx-repeat>
+      <fx-fore>
+        <fx-model id="record">
+          <fx-instance>
+            <data>
+              <task>one</task>
+              <task>two</task>
+              <task>three</task>
+            </data>
+          </fx-instance>
+        </fx-model>
+        <fx-repeat focus-on-create="task" id="todos" ref="task">
+          <template>
+            <fx-control id="task" ref="."></fx-control>
+          </template>
+        </fx-repeat>
 
-                <fx-trigger>
-                    <button>insert at end</button>
-                    <fx-insert ref="task" at="index('todos')" position="before"></fx-insert>
-                </fx-trigger>
-            </fx-fore>
+        <fx-trigger>
+          <button>insert at end</button>
+          <fx-insert
+            ref="task"
+            at="index('todos')"
+            position="before"
+            keep-values="true"
+          ></fx-insert>
+        </fx-trigger>
+      </fx-fore>
     `);
+
     await oneEvent(el, 'refresh-done');
     const trigger = el.querySelector('fx-trigger');
     trigger.performActions();
@@ -339,8 +338,5 @@ describe('insert Tests', () => {
     expect(tasks.length).to.equal(4);
 
     expect(tasks[0].textContent).to.equal('three');
-
   });
-
-
 });


### PR DESCRIPTION
Sorry for the reformat. Just using the bundled prettier and all. Let's discuss how to handle this a bit better in the future....

Basically, the main reason a bunch of tests failed was because of small mistakes: at one test, an instance called `templ` was declared, but queried as `templ`. For the other tests, the test asserted like the `keep-values` attribute was enabled, but the fixture did not enable the attribute.

One open thing:

```
HierarchyRequestError: Failed to execute 'insertAdjacentElement' on 'Element': Only one element on document allowed.
    at HTMLElement.perform (base/src/actions/fx-insert.js:124:21)
    at HTMLElement.execute (base/src/actions/abstract-action.js:85:12)
    at HTMLElement.performActions (base/src/ui/fx-trigger.js:68:15)
    at Context.<anonymous> (base/test/insert.test.js:220:13)
```

This is happening because some target sequence points to a `data` element. The `insert` then attempts to insert new elements _next to_ that `data` element. Which fails because that `data` element is a documentElement. This came floating to the top after replacing a bunch of `evaluateXPath` calls with the specific version: if you know an XPath evaluates to a sequence of Nodes, it is usually better to use evaluateToNodes: evaluate MAY return empty arrays or single nodes. 

@JoernT what do you think about the defaulting of the `data` element? I am a bit unsure where to best place that defaulting...

