### PR TITLE
[Draft] Embedded forms!

### DIFF
--- a/demo/repeat-subform.html
+++ b/demo/repeat-subform.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" name="viewport"/>
+
+    <title>repeat with sequences</title>
+
+    <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <link href="../resources/demo.css" rel="stylesheet">
+
+    <style>
+      [unresolved] {
+          display: none;
+      }
+
+      fx-repeat {
+          padding: 20px;
+          display: block;
+          height: auto;
+      }
+
+      fx-repeatitem {
+          /*border: thin solid white;*/
+          /*background: lightsteelblue;*/
+          margin: 0.5rem 0;
+          display: grid;
+
+      }
+      fx-control {
+          display: inline-block;
+          padding: 0 6px;
+          white-space: nowrap;
+
+          /*padding: 6px;*/
+          /*margin: 4px;*/
+      }
+      fx-trigger{
+          display: inline-block;
+      }
+    </style>
+  </head>
+  <body unresolved="unresolved">
+
+	<fx-fore id="thesubform" class="widget">
+	  <fx-model>
+		<fx-instance><data/></fx-instance>
+
+	  </fx-model>
+
+	  <label>instance ({.}):</label><fx-control ref="."/>
+	</fx-fore>
+
+	<div class="wrapper">
+      <demo-snippet>
+        <template>
+
+          <fx-fore>
+            <fx-model>
+			  <fx-instance>
+                <data><item>A</item><item>B</item><item>C</item><item>D</item></data>
+              </fx-instance>
+
+            </fx-model>
+
+            <h1>Repeat from sequence</h1>
+            <fx-repeat ref="item">
+              <template>
+				<fx-control uri="#thesubform" initial="."/>
+              </template>
+            </fx-repeat>
+
+			<fx-repeat ref="item">
+              <template>
+				<label>{.}</label>
+              </template>
+            </fx-repeat>
+
+          </fx-fore>
+        </template>
+      </demo-snippet>
+	</div>
+	<script type="module" src="./demo.js"></script>
+
+  </body>
+</html>

--- a/demo/repeat-subform.html
+++ b/demo/repeat-subform.html
@@ -42,15 +42,16 @@
   </head>
   <body unresolved="unresolved">
 
-	<fx-fore id="thesubform" class="widget">
+<template id="thesubform">
+	<fx-fore>
 	  <fx-model>
 		<fx-instance><data/></fx-instance>
 
 	  </fx-model>
 
-	  <label>instance ({.}):</label><fx-control ref="."/>
+	  <label>instance ({.}) (updating on input):</label><fx-control ref="." update-event="input"/>
 	</fx-fore>
-
+</template>
 	<div class="wrapper">
       <demo-snippet>
         <template>
@@ -63,7 +64,7 @@
 
             </fx-model>
 
-            <h1>Repeat from sequence</h1>
+            <h1>Repeat from sequence: Updating on blur</h1>
             <fx-repeat ref="item">
               <template>
 				<fx-control uri="#thesubform" initial="."/>

--- a/doc/demos.html
+++ b/doc/demos.html
@@ -114,6 +114,12 @@
             <h3><a href="../demo/docbook-bibliography.html" target="_blank">DocBook Bibliography - editing namespaced XML</a></h3>
         </section>
 
+		<section>
+		  <h2>WIP</h2>
+
+		  <h3><a href="../demo/repeat-subform.html" target="_blank">Using sub forms</a></h3>
+		</section>
+
     </div>
 </body>
 </html>

--- a/src/ui/fx-control.js
+++ b/src/ui/fx-control.js
@@ -31,21 +31,36 @@ class FxControl extends XfAbstractControl {
             }
         `;
 
-    /*
-        const controlHtml = `
-            <slot></slot>
-            <fx-setvalue id="setvalue" ref="${this.ref}"></fx-setvalue>
-        `;
-*/
+    if (this.hasAttribute('uri')) {
+      const subForm = this.ownerDocument.querySelector(this.getAttribute('uri'));
 
-    /*
-        this.shadowRoot.innerHTML = `
-            <style>
-                ${style}
-            </style>
-            ${controlHtml}
-        `
-*/
+      const localSubForm = this.shadowRoot.appendChild(subForm.cloneNode(true));
+      localSubForm.addEventListener(this.updateEvent, () => {
+        console.log('NEW VALUE~!!!!!!');
+      });
+
+      const ref = this.getAttribute('initial');
+      this.ref = ref;
+      this.evalInContext();
+      const referencedThing = Array.isArray(this.nodeset) ? this.nodeset[0] : this.nodeset;
+      // const referencedThing = evaluateXPathToFirstNode(ref, this.getInScopeContext(), this);
+      // Assume this is an element!
+
+      // TODO: use actual setters
+      const fxInstance = localSubForm.getModel().querySelector('fx-instance');
+      fxInstance.innerHTML = referencedThing.outerHTML;
+      // TODO: DRY THIS OUT!
+      this.widget = this.getWidget();
+      console.log('widget ', this.widget);
+      this.addEventListener(this.updateEvent, () => {
+        console.log('eventlistener ', this.updateEvent, localSubForm);
+        // const newValue = localSubForm.getModel().getModelItem(fxInstance.firstChild).value;
+        this.setValue('I have been changed! TODO: getting the new value would be swell!');
+      });
+      const div = this.shadowRoot.appendChild(document.createElement('div'));
+      div.innerHTML = `<fx-setvalue id="setvalue" ref="${ref}"></fx-setvalue>`;
+      return;
+    }
     this.shadowRoot.innerHTML = `
             <style>
                 ${style}

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -145,7 +145,13 @@ registerCustomXPathFunction(
   'xs:integer?',
   (dynamicContext, string) => {
     const { formElement } = dynamicContext.currentContext;
-    const repeat = string ? formElement.querySelector(`fx-repeat[id=${string}]`) : null;
+    if (!string) {
+      return 1;
+    }
+
+    const repeat = formElement
+      .querySelectorAll(`fx-repeat[id=${string}]`)
+      .filter(repeat => repeat.closest('xf-fore') === formElement);
 
     // const def = instance.getInstanceData();
     if (repeat) {


### PR DESCRIPTION
This introduces a new `uri` attribute on `fx-control` that indicates the control is actually a whole other `fx-fore` element.

TODO:

- [x] Inlining the form
- [ ] Loading the form from an external resource
- [x] Passing the initial data
- [x] Receiving new values
- [ ] Passing new values in

Creating a draft PR for visibility!