### PR TITLE
Upgrade FontoXPath to 3.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@jinntec/jinn-toast": "^1.0.3",
-        "fontoxpath": "^3.25.1"
+        "fontoxpath": "^3.26.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.13.0",
@@ -2340,8 +2340,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/karma": {
       "version": "5.0.1",
@@ -2863,7 +2862,6 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
       "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -2913,7 +2911,6 @@
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
       "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -4572,7 +4569,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5077,7 +5073,6 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
       "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -5097,15 +5092,13 @@
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/domhandler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
       "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "domelementtype": "^2.1.0"
       },
@@ -5121,7 +5114,6 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
       "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
@@ -5348,7 +5340,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -5686,7 +5677,6 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
       "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "debug": "^2.6.9",
         "resolve": "^1.13.1"
@@ -5697,7 +5687,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5706,15 +5695,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint-module-utils": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
       "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
@@ -5728,7 +5715,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5737,15 +5723,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint-plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz",
       "integrity": "sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-rule-composer": "^0.3.0"
       },
@@ -5761,7 +5745,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.1.2.tgz",
       "integrity": "sha512-bhBIRyZFqI4EoF12lGDHAmgfff8eLXx6R52/K3ESQhsxzCzIE6hdebS7Py651f7U3RBotqroUnC3L29bR7qJWQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "htmlparser2": "^6.0.1"
       }
@@ -5771,7 +5754,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
       "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -5799,7 +5781,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5809,7 +5790,6 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2",
         "isarray": "^1.0.0"
@@ -5822,22 +5802,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint-plugin-lit": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.6.1.tgz",
       "integrity": "sha512-BpPoWVhf8dQ/Sz5Pi9NlqbGoH5BcMcVyXhi2XTx2XGMAO9U2lS+GTSsqJjI5hL3OuxCicNiUEWXazAwi9cAGxQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "parse5": "^6.0.1",
         "parse5-htmlparser2-tree-adapter": "^6.0.1",
@@ -5854,15 +5831,13 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/eslint-plugin-no-only-tests": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz",
       "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5872,7 +5847,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-wc/-/eslint-plugin-wc-1.3.1.tgz",
       "integrity": "sha512-2y+ezPwKFm470Pq2dvdkHXEjzCSqo6B2Iqh9gJQFGXs1kvvcYXR+gDvJNICI68utlszVUakt0DYG83uzJnfCKg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-valid-element-name": "^1.0.0",
         "js-levenshtein-esm": "^1.2.0"
@@ -5886,7 +5860,6 @@
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -6591,9 +6564,9 @@
       }
     },
     "node_modules/fontoxpath": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.25.1.tgz",
-      "integrity": "sha512-LoRuWATH5Mmg1rfJ6QFRveneqLQ5a+wQbffER4W9f+os2WTLcbjfVpXnv0kRMHyGpLDlhxyeJuLptaumGSS2Yw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.26.0.tgz",
+      "integrity": "sha512-NFFzewI4EkWhc/hjrGKzrNXHjhYVqLrJptnvbsFetGGXVLeUf7D7IQ3/bgY6bqQPtHf7LmSmZemfhstAhgxRAg==",
       "dependencies": {
         "prsc": "2.0.1",
         "xspattern": "^2.0.0"
@@ -7219,7 +7192,6 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "peer": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -8274,8 +8246,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -8406,7 +8377,6 @@
       "resolved": "https://registry.npmjs.org/is-valid-element-name/-/is-valid-element-name-1.0.0.tgz",
       "integrity": "sha1-Ju8/12zfHxItEFQG4y01sN4AWYE=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-potential-custom-element-name": "^1.0.0"
       }
@@ -8563,8 +8533,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz",
       "integrity": "sha512-fzreKVq1eD7eGcQr7MtRpQH94f8gIfhdrc7yeih38xh684TNMK9v5aAu2wxfIRMk/GpAJRrzcirMAPIaSDaByQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -12133,7 +12102,6 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
       "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -12695,7 +12663,6 @@
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
       "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "parse5": "^6.0.1"
       }
@@ -12704,8 +12671,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/parseqs": {
       "version": "0.0.6",
@@ -12904,7 +12870,6 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "find-up": "^2.1.0"
       },
@@ -12917,7 +12882,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -12930,7 +12894,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -12944,7 +12907,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -12957,7 +12919,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -12970,7 +12931,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -13313,7 +13273,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
@@ -13327,7 +13286,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -13340,7 +13298,6 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -13356,7 +13313,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -13370,7 +13326,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -13383,7 +13338,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -13396,7 +13350,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -13406,7 +13359,6 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -13419,7 +13371,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "pify": "^2.0.0"
       },
@@ -13432,7 +13383,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13442,7 +13392,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "load-json-file": "^2.0.0",
         "normalize-package-data": "^2.3.2",
@@ -13738,7 +13687,6 @@
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.5"
       }
@@ -15562,7 +15510,6 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
       "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -15575,7 +15522,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -18345,7 +18291,13 @@
       "requires": {
         "babel-eslint": "^10.0.3",
         "eslint": "^6.7.2",
-        "eslint-config-airbnb-base": "^14.0.0"
+        "eslint-config-airbnb-base": "^14.0.0",
+        "eslint-plugin-babel": "^5.3.0",
+        "eslint-plugin-html": "^6.0.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-lit": "^1.2.0",
+        "eslint-plugin-no-only-tests": "^2.4.0",
+        "eslint-plugin-wc": "^1.2.0"
       }
     },
     "@open-wc/karma-esm": {
@@ -19085,8 +19037,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/karma": {
       "version": "5.0.1",
@@ -19552,7 +19503,6 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
       "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -19587,7 +19537,6 @@
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
       "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -20896,8 +20845,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -21290,7 +21238,6 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
       "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -21301,15 +21248,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "domhandler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
       "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "domelementtype": "^2.1.0"
       }
@@ -21319,7 +21264,6 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
       "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
@@ -21531,8 +21475,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -21819,7 +21762,6 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
       "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.13.1"
@@ -21830,7 +21772,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -21839,8 +21780,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -21849,7 +21789,6 @@
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
       "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
@@ -21860,7 +21799,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -21869,8 +21807,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -21879,7 +21816,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz",
       "integrity": "sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "eslint-rule-composer": "^0.3.0"
       }
@@ -21889,7 +21825,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-6.1.2.tgz",
       "integrity": "sha512-bhBIRyZFqI4EoF12lGDHAmgfff8eLXx6R52/K3ESQhsxzCzIE6hdebS7Py651f7U3RBotqroUnC3L29bR7qJWQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "htmlparser2": "^6.0.1"
       }
@@ -21899,7 +21834,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
       "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -21921,7 +21855,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -21931,7 +21864,6 @@
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
-          "peer": true,
           "requires": {
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
@@ -21941,15 +21873,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -21958,7 +21888,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.6.1.tgz",
       "integrity": "sha512-BpPoWVhf8dQ/Sz5Pi9NlqbGoH5BcMcVyXhi2XTx2XGMAO9U2lS+GTSsqJjI5hL3OuxCicNiUEWXazAwi9cAGxQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "parse5": "^6.0.1",
         "parse5-htmlparser2-tree-adapter": "^6.0.1",
@@ -21969,8 +21898,7 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
           "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -21978,15 +21906,13 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz",
       "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "eslint-plugin-wc": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-wc/-/eslint-plugin-wc-1.3.1.tgz",
       "integrity": "sha512-2y+ezPwKFm470Pq2dvdkHXEjzCSqo6B2Iqh9gJQFGXs1kvvcYXR+gDvJNICI68utlszVUakt0DYG83uzJnfCKg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "is-valid-element-name": "^1.0.0",
         "js-levenshtein-esm": "^1.2.0"
@@ -21996,8 +21922,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -22527,9 +22452,9 @@
       "dev": true
     },
     "fontoxpath": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.25.1.tgz",
-      "integrity": "sha512-LoRuWATH5Mmg1rfJ6QFRveneqLQ5a+wQbffER4W9f+os2WTLcbjfVpXnv0kRMHyGpLDlhxyeJuLptaumGSS2Yw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.26.0.tgz",
+      "integrity": "sha512-NFFzewI4EkWhc/hjrGKzrNXHjhYVqLrJptnvbsFetGGXVLeUf7D7IQ3/bgY6bqQPtHf7LmSmZemfhstAhgxRAg==",
       "requires": {
         "prsc": "2.0.1",
         "xspattern": "^2.0.0"
@@ -23010,7 +22935,6 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
       "integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -23801,8 +23725,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "is-promise": {
       "version": "2.2.2",
@@ -23894,7 +23817,6 @@
       "resolved": "https://registry.npmjs.org/is-valid-element-name/-/is-valid-element-name-1.0.0.tgz",
       "integrity": "sha1-Ju8/12zfHxItEFQG4y01sN4AWYE=",
       "dev": true,
-      "peer": true,
       "requires": {
         "is-potential-custom-element-name": "^1.0.0"
       }
@@ -24015,8 +23937,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz",
       "integrity": "sha512-fzreKVq1eD7eGcQr7MtRpQH94f8gIfhdrc7yeih38xh684TNMK9v5aAu2wxfIRMk/GpAJRrzcirMAPIaSDaByQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -26825,7 +26746,6 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
       "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -27252,7 +27172,6 @@
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
       "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "parse5": "^6.0.1"
       },
@@ -27261,8 +27180,7 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
           "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -27429,7 +27347,6 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
-      "peer": true,
       "requires": {
         "find-up": "^2.1.0"
       },
@@ -27439,7 +27356,6 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
-          "peer": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -27449,7 +27365,6 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
-          "peer": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -27460,7 +27375,6 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
-          "peer": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -27470,7 +27384,6 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
-          "peer": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
@@ -27479,8 +27392,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -27740,7 +27652,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
-      "peer": true,
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
@@ -27751,7 +27662,6 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
-          "peer": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -27761,7 +27671,6 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
-          "peer": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
@@ -27774,7 +27683,6 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
-          "peer": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -27785,7 +27693,6 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
-          "peer": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -27795,7 +27702,6 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
-          "peer": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
@@ -27804,15 +27710,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
-          "peer": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -27822,7 +27726,6 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
-          "peer": true,
           "requires": {
             "pify": "^2.0.0"
           }
@@ -27831,15 +27734,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
-          "peer": true,
           "requires": {
             "load-json-file": "^2.0.0",
             "normalize-package-data": "^2.3.2",
@@ -28081,8 +27982,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -29584,7 +29484,6 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
       "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -29597,7 +29496,6 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
-          "peer": true,
           "requires": {
             "minimist": "^1.2.0"
           }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@jinntec/jinn-toast": "^1.0.3",
-    "fontoxpath": "^3.25.1"
+    "fontoxpath": "^3.26.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.13.0",

--- a/src/DependencyNotifyingDomFacade.js
+++ b/src/DependencyNotifyingDomFacade.js
@@ -45,15 +45,6 @@ export class DependencyNotifyingDomFacade {
    * @param  bucket - The bucket that matches the attribute that will be used.
    */
   // eslint-disable-next-line class-methods-use-this
-  /*
-  getChildNodes(node, bucket) {
-    const matchingNodes = Array.from(node.childNodes).filter(
-      childNode => !bucket || getBucketsForNode(childNode).includes(bucket),
-    );
-    return matchingNodes;
-  }
-*/
-
   getChildNodes(node, bucket) {
     const matchingNodes = Array.from(node.childNodes).filter(
       childNode => !bucket || getBucketsForNode(childNode).includes(bucket),
@@ -87,7 +78,7 @@ export class DependencyNotifyingDomFacade {
   getFirstChild(node, bucket) {
     for (const child of node.childNodes) {
       if (!bucket || getBucketsForNode(child).includes(bucket)) {
-        this._onNodeTouched(node);
+        this._onNodeTouched(child);
         return child;
       }
     }
@@ -122,12 +113,13 @@ export class DependencyNotifyingDomFacade {
    */
   // eslint-disable-next-line class-methods-use-this
   getNextSibling(node, bucket) {
-    for (let { nextSibling } = node; nextSibling; nextSibling = nextSibling.nextSibling) {
-      if (!getBucketsForNode(nextSibling).includes(bucket)) {
+    for (let sibling = node.nextSibling; sibling; sibling = sibling.nextSibling) {
+      if (!getBucketsForNode(sibling).includes(bucket)) {
         // eslint-disable-next-line no-continue
         continue;
       }
-      return nextSibling;
+      this._onNodeTouched(sibling);
+      return sibling;
     }
     return null;
   }


### PR DESCRIPTION
Fixes (part of) #111, where all children were listed as dependencies when recalculating a form