### PR TITLE
Make functions that are declared without a prefix available always

### DIFF
--- a/src/functions/fx-function.js
+++ b/src/functions/fx-function.js
@@ -2,6 +2,8 @@ import { registerCustomXPathFunction } from 'fontoxpath';
 import { foreElementMixin } from '../ForeElementMixin.js';
 import { evaluateXPath } from '../xpath-evaluation.js';
 
+export const globallyDeclaredFunctionLocalNames = [];
+
 /**
  * Allows to extend a form with local custom functions.
  *
@@ -41,9 +43,15 @@ export class FxFunction extends foreElementMixin(HTMLElement) {
 
     // TODO: lookup prefix
     const functionIdentifier =
-      prefix === 'local'
+      prefix === 'local' || !prefix
         ? { namespaceURI: 'http://www.w3.org/2005/xquery-local-functions', localName }
         : `${prefix}:${localName}`;
+
+    // Make the function available globally w/o a prefix. See the functionNameResolver for for how
+    // this is picked up
+    if (!prefix) {
+      globallyDeclaredFunctionLocalNames.push(localName);
+    }
 
     const paramParts = params
       ? params.split(',').map(param => {

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -12,6 +12,7 @@ import {
 } from 'fontoxpath';
 import { Fore } from './fore.js';
 
+import { globallyDeclaredFunctionLocalNames } from './functions/fx-function.js';
 import { XPathUtil } from './xpath-util.js';
 
 const XFORMS_NAMESPACE_URI = 'http://www.w3.org/2002/xforms';
@@ -183,7 +184,12 @@ function functionNameResolver({ prefix, localName }, _arity) {
     case 'logtree':
       return { namespaceURI: XFORMS_NAMESPACE_URI, localName };
     default:
-      if (prefix === '' || prefix === 'fn') {
+      if (prefix === '' && globallyDeclaredFunctionLocalNames.includes(localName)) {
+        // The function has been declared without a prefix and is called here without a prefix.
+        // Just make this work. It is the developer-friendly way
+        return { namespaceURI: 'http://www.w3.org/2005/xquery-local-functions', localName };
+      }
+      if (prefix === 'fn') {
         return { namespaceURI: 'http://www.w3.org/2005/xpath-functions', localName };
       }
       if (prefix === 'local') {
@@ -212,7 +218,7 @@ function getVariablesInScope(formElement) {
   }
 
   const variables = {};
-  if(closestActualFormElement.inScopeVariables){
+  if (closestActualFormElement.inScopeVariables) {
     for (const key of closestActualFormElement.inScopeVariables.keys()) {
       const varElement = closestActualFormElement.inScopeVariables.get(key);
       variables[key] = varElement.value;
@@ -749,8 +755,8 @@ registerCustomXPathFunction(
   ['xs:string?'],
   'item()?',
   (dynamicContext, arg) => {
-    if(!dynamicContext.currentContext.variables) return [];
-    if(!arg) return [];
+    if (!dynamicContext.currentContext.variables) return [];
+    if (!arg) return [];
     const payload = dynamicContext.currentContext.variables[arg];
     if (payload.nodeType) {
       console.log('got some node as js object');

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -1,4 +1,4 @@
-import { html, oneEvent, fixtureSync, expect, elementUpdated } from '@open-wc/testing';
+import { html, oneEvent, fixtureSync, expect } from '@open-wc/testing';
 
 import '../index.js';
 
@@ -63,6 +63,24 @@ describe('functions', () => {
             </fx-function>
           </fx-model>
           <label>{local:hello-world()}</label>
+        </fx-fore>
+      `);
+
+      await oneEvent(el, 'refresh-done');
+
+      const label = el.querySelector('label');
+      expect(label.innerText).to.equal('Hello World');
+    });
+
+    it('can define a simple function without any prefix', async () => {
+      const el = await fixtureSync(html`
+        <fx-fore>
+          <fx-model>
+            <fx-function signature="hello-world() as xs:string" override="no" type="text/xpath">
+              ("Hello", "World") =&gt; string-join(" ")
+            </fx-function>
+          </fx-model>
+          <label>{hello-world()}</label>
         </fx-fore>
       `);
 


### PR DESCRIPTION
This makes the following work:

```
  <fx-function signature="now() as xs:string" type="text/javascript">
      return new Date().toLocaleTimeString();
  </fx-function>

 {now()}
 ```

Which is a lot more friendly than repeating prefixes all over the place.

Fixes #126 