### PR TITLE
Fix usage of functions in refs

### DIFF
--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -295,7 +295,7 @@ function functionNameResolver({prefix, localName}, _arity) {
                 // Just make this work. It is the developer-friendly way
                 return {namespaceURI: 'http://www.w3.org/2005/xquery-local-functions', localName};
             }
-            if (prefix === 'fn') {
+            if (prefix === 'fn' || prefix === '') {
                 return {namespaceURI: 'http://www.w3.org/2005/xpath-functions', localName};
             }
             if (prefix === 'local') {
@@ -379,6 +379,7 @@ export function evaluateXPathToFirstNode(xpath, contextNode, formElement) {
             xf: XFORMS_NAMESPACE_URI,
         },
         currentContext: {formElement},
+        functionNameResolver,
         namespaceResolver,
     });
 }

--- a/test/insert.test.js
+++ b/test/insert.test.js
@@ -495,7 +495,7 @@ describe('insert Tests', () => {
             </data>
           </fx-instance>
         </fx-model>
-        <fx-group ref="//entry">
+        <fx-group ref="//entry[true()]">
           <fx-trigger id="addGrp">
             <button>add</button>
             <fx-insert

--- a/test/setvalue.test.js
+++ b/test/setvalue.test.js
@@ -17,7 +17,7 @@ describe('setvalue tests', () => {
         </fx-model>
 
         <fx-group>
-          <fx-output id="output" ref="greeting"></fx-output>
+          <fx-output id="output" ref="greeting[true()]"></fx-output>
           <fx-trigger id="btn" label="say 'hello Universe'">
             <fx-setvalue ref="greeting">Hello Universe</fx-setvalue>
           </fx-trigger>


### PR DESCRIPTION
Pass functionnameresolver always
Make the functionnameresolver explicitly bind the empty prefix for functions to 'fn'

This fixes #151 