### PR TITLE
Micro-optimize template finding and instance finding

### DIFF
--- a/src/fx-fore.js
+++ b/src/fx-fore.js
@@ -466,7 +466,7 @@ export class FxFore extends HTMLElement {
     _updateTemplateExpressions() {
         // Note the fact we're going over HTML here: therefore the `html` prefix.
         const search =
-            "(descendant-or-self::*!(text(), @*))[matches(.,'\\{.*\\}')][not(ancestor-or-self::fx-model)]";
+            "(descendant-or-self::*!(text(), @*))[contains(., '{')][matches(.,'\\{.*\\}')][not(ancestor-or-self::fx-model)]";
 
         const tmplExpressions = evaluateXPathToNodes(search, this, this);
         // console.log('template expressions found ', tmplExpressions);

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -192,7 +192,9 @@ function createNamespaceResolver(xpathQuery, formElement) {
 	let instanceReferences = findInstanceReferences(xpathQuery);
     if (instanceReferences.length === 0) {
         // No instance functions. Look up further in the hierarchy to see if we can deduce the intended context from there
-        const ancestorComponent = formElement.parentNode.closest('[ref]');
+        const ancestorComponent = formElement.parentNode &&
+			  formElement.parentNode.nodeType === formElement.ELEMENT &&
+			  formElement.parentNode.closest('[ref]');
         if (ancestorComponent) {
             const resolver = createNamespaceResolver(
                 ancestorComponent.getAttribute('ref'),

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -192,7 +192,7 @@ function createNamespaceResolver(xpathQuery, formElement) {
 	let instanceReferences = findInstanceReferences(xpathQuery);
     if (instanceReferences.length === 0) {
         // No instance functions. Look up further in the hierarchy to see if we can deduce the intended context from there
-        const ancestorComponent = fxEvaluateXPathToFirstNode('ancestor::*[@ref][1]', formElement);
+        const ancestorComponent = formElement.parentNode.closest('[ref]');
         if (ancestorComponent) {
             const resolver = createNamespaceResolver(
                 ancestorComponent.getAttribute('ref'),


### PR DESCRIPTION
Two XPath parts. Makes the large-repeat performance test take ~750ms instead of ~1500ms