### PR TITLE
allow text/xml responses and do not allow unhandled content types

### DIFF
--- a/src/fx-instance.js
+++ b/src/fx-instance.js
@@ -30,12 +30,14 @@ async function handleResponse(response) {
     // console.log("********** inside res json *********");
     return response.json();
   }
-  if (responseContentType.startsWith('application/xml')) {
+  if (responseContentType.startsWith('application/xml') ||
+      responseContentType.startsWith('text/xml')) {
+    // See https://www.rfc-editor.org/rfc/rfc7303
     const text = await response.text();
     // console.log('xml ********', result);
     return new DOMParser().parseFromString(text, 'application/xml');
   }
-  return 'done';
+  throw new Error(`unable to handle response content type: ${responseContentType}`);
 }
 
 /**


### PR DESCRIPTION
According to RFC 7303, the response content type `text/xml` is allowed as an alias for `application/xml`.
It took me a while to figure out why my model was not loaded, because nothing was shown when the content type is not recognized. I think Fore should throw an error in that case.