### PR TITLE
Remove position:relative for code containers

### DIFF
--- a/demo/js/demo-snippet.js
+++ b/demo/js/demo-snippet.js
@@ -79,7 +79,6 @@ Polymer({
         background-color: #f5f5f5;
         font-size: 13px;
         overflow: auto;
-        position: relative;
         padding: 0 20px;
         z-index: -1;
         @apply --demo-snippet-code;


### PR DESCRIPTION
This makes the scrollbar work again, like it's supposed to