### PR TITLE
Use dependency tracking in repeats

### DIFF
--- a/src/DependencyNotifyingDomFacade.js
+++ b/src/DependencyNotifyingDomFacade.js
@@ -114,7 +114,7 @@ export class DependencyNotifyingDomFacade {
   // eslint-disable-next-line class-methods-use-this
   getNextSibling(node, bucket) {
     for (let sibling = node.nextSibling; sibling; sibling = sibling.nextSibling) {
-      if (!getBucketsForNode(sibling).includes(bucket)) {
+      if (bucket && !getBucketsForNode(sibling).includes(bucket)) {
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -149,7 +149,7 @@ export class DependencyNotifyingDomFacade {
       previousSibling;
       previousSibling = previousSibling.previousSibling
     ) {
-      if (!getBucketsForNode(previousSibling).includes(bucket)) {
+      if (bucket && !getBucketsForNode(previousSibling).includes(bucket)) {
         // eslint-disable-next-line no-continue
         continue;
       }

--- a/src/actions/fx-insert.js
+++ b/src/actions/fx-insert.js
@@ -228,10 +228,11 @@ export class FxInsert extends AbstractAction {
     // console.log('instance ', this.getModel().getDefaultContext());
     // Fore.dispatch()
 
-	  const instanceId = XPathUtil.resolveInstance(this, this.ref);
+	  const instanceId = XPathUtil.resolveInstance(this, this.getAttribute('context'));
     const inst = this.getModel().getInstance(instanceId);
       // console.log('<<<<<<< resolved instance', inst);
-	  const xpath = XPathUtil.getPath(insertLocationNode.parentNode, instanceId);
+	  // Note: the parent to insert under is always the parent of the inserted node. The 'context' is not always the parent if the sequence is empty, or the position is different
+	  const xpath = XPathUtil.getPath(originSequenceClone.parentNode, instanceId);
 
 
     const path = Fore.getDomNodeIndexString(originSequenceClone);
@@ -280,7 +281,7 @@ export class FxInsert extends AbstractAction {
   }
 
   actionPerformed(changedPaths) {
-    this.getModel().rebuild();
+//    this.getModel().rebuild();
     super.actionPerformed(changedPaths);
   }
 

--- a/src/actions/fx-insert.js
+++ b/src/actions/fx-insert.js
@@ -221,14 +221,18 @@ export class FxInsert extends AbstractAction {
         }
       }
     }
+	  // instance('default')/items/item[index()]
 
     // console.log('insert context item ', insertLocationNode);
     // console.log('parent ', insertLocationNode.parentNode);
     // console.log('instance ', this.getModel().getDefaultContext());
     // Fore.dispatch()
 
-    const inst = this.getModel().getInstance(XPathUtil.resolveInstance(this));
-    // console.log('<<<<<<< resolved instance', inst);
+	  const instanceId = XPathUtil.resolveInstance(this, this.ref);
+    const inst = this.getModel().getInstance(instanceId);
+      // console.log('<<<<<<< resolved instance', inst);
+	  const xpath = XPathUtil.getPath(insertLocationNode.parentNode, instanceId);
+
 
     const path = Fore.getDomNodeIndexString(originSequenceClone);
     this.dispatchEvent(
@@ -259,7 +263,9 @@ export class FxInsert extends AbstractAction {
       }),
     );
 
-    this.needsUpdate = true;
+      this.needsUpdate = true;
+	  console.log('Changed!', xpath)
+	  return [xpath];
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -273,9 +279,9 @@ export class FxInsert extends AbstractAction {
     return null;
   }
 
-  actionPerformed() {
+  actionPerformed(changedPaths) {
     this.getModel().rebuild();
-    super.actionPerformed();
+    super.actionPerformed(changedPaths);
   }
 
   /**

--- a/src/fx-fore.js
+++ b/src/fx-fore.js
@@ -748,21 +748,16 @@ export class FxFore extends HTMLElement {
      */
     async _lazyCreateInstance() {
         const model = this.querySelector('fx-model');
-				// Inherit shared models from the parent component
+        // Inherit shared models from the parent component
 
-			const parentFore = this.parentNode.closest('fx-fore');
+        const parentFore = this.parentNode.closest('fx-fore');
 		if (parentFore) {
 			const sharedInstances = Array.from(parentFore.getModel().querySelectorAll('fx-instance')).filter(instance => instance.hasAttribute('shared'));
-
 				for(const instance of sharedInstances) {
-					if (this.getModel().getInstance(instance.id)) {
-						// don't overwrite. error maybe even?
-						continue;
-					}
 					this.getModel().instances.push(instance);
 				}
 			this.getModel().updateModel();
-			}
+		}
 
 
         if (model.instances.length === 0) {

--- a/src/fx-fore.js
+++ b/src/fx-fore.js
@@ -464,6 +464,24 @@ export class FxFore extends HTMLElement {
 					)
 					.filter(Boolean)
 			);
+
+			for(const changedPath of changedPaths) {
+				for (const repeat of this.querySelectorAll('fx-repeat')) {
+					if (repeat.closest('fx-fore') !== this) {
+						continue;
+					}
+
+					if (repeat.touchedPaths.has(changedPath)) {
+						// Make a temporary model-item-like structure for this
+						this.toRefresh.push({
+							path: changedPath,
+							boundControls: [repeat]
+						});
+
+						console.log('Found a repeat to update!!!', repeat)
+					}
+				}
+			}
 		}
 		if (this.isRefreshing) {
 			return;

--- a/src/ui/abstract-control.js
+++ b/src/ui/abstract-control.js
@@ -2,8 +2,8 @@ import '../fx-model.js';
 import { foreElementMixin } from '../ForeElementMixin.js';
 import { ModelItem } from '../modelitem.js';
 import { Fore } from '../fore.js';
-import {XPathUtil} from "../xpath-util";
-import getInScopeContext from "../getInScopeContext";
+import { XPathUtil } from '../xpath-util.js';
+import getInScopeContext from '../getInScopeContext.js';
 import { evaluateXPathToFirstNode} from '../xpath-evaluation.js';
 
 /**
@@ -76,7 +76,7 @@ export default class AbstractControl extends foreElementMixin(HTMLElement) {
         const create = this.closest('[create]');
         if(create){
           // ### check if parent element exists
-          let attrName,parentPath, parentNode;
+          let attrName; let parentPath; let parentNode;
 
           if(this.ref.includes('/')){
             parentPath = this.ref.substring(0, this.ref.indexOf('/'));
@@ -92,7 +92,7 @@ export default class AbstractControl extends foreElementMixin(HTMLElement) {
               }
             }
           }else{
-            let inscope = getInScopeContext(this, this.ref);
+            const inscope = getInScopeContext(this, this.ref);
 
             if(this.ref.includes('@')) {
               attrName = this.ref.substring(this.ref.indexOf('@') + 1);

--- a/src/ui/fx-repeat.js
+++ b/src/ui/fx-repeat.js
@@ -132,7 +132,7 @@ export class FxRepeat extends foreElementMixin(HTMLElement) {
       if (mutations[0].type === 'childList') {
         const added = mutations[0].addedNodes[0];
         if (added) {
-          const instance = XPathUtil.resolveInstance(this);
+			const instance = XPathUtil.resolveInstance(this, this.ref);
 			const path = XPathUtil.getPath(added, instance);
           // console.log('path mutated', path);
           // this.dispatch('path-mutated',{'path':path,'nodeset':this.nodeset,'index': this.index});
@@ -228,12 +228,6 @@ export class FxRepeat extends foreElementMixin(HTMLElement) {
     if (!this.inited) this.init();
     // console.time('repeat-refresh', this);
     this._evalNodeset();
-
-	const modelItem = this.getModelItem();
-    // ### register ourselves as boundControl
-    if (!modelItem.boundControls.includes(this)) {
-	  modelItem.boundControls.push(this);
-    }
 
     // console.log('repeat refresh nodeset ', this.nodeset);
     // console.log('repeatCount', this.repeatCount);

--- a/src/ui/fx-repeatitem.js
+++ b/src/ui/fx-repeatitem.js
@@ -58,7 +58,9 @@ export class FxRepeatitem extends foreElementMixin(HTMLElement) {
     this.shadowRoot.innerHTML = `
             ${html}
         `;
-    this.getOwnerForm().registerLazyElement(this);
+      this.getOwnerForm().registerLazyElement(this);
+
+	  this.ref = `${this.parentNode.ref}`;
   }
 
   disconnectedCallback() {

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -418,14 +418,14 @@ function getVariablesInScope(formElement) {
  * @param  {Node} contextNode The start of the XPath
  * @param  {{parentNode}|ForeElementMixin} formElement  The form element associated to the XPath
  */
-export function evaluateXPath(xpath, contextNode, formElement, variables = {}, options={}) {
+export function evaluateXPath(xpath, contextNode, formElement, variables = {}, options={}, domFacade = null) {
     const namespaceResolver = createNamespaceResolverForNode(xpath, contextNode, formElement);
     const variablesInScope = getVariablesInScope(formElement);
 
     return fxEvaluateXPath(
         xpath,
         contextNode,
-        null,
+        domFacade,
         {...variablesInScope, ...variables},
         fxEvaluateXPath.ALL_RESULTS_TYPE,
         {

--- a/src/xpath-util.js
+++ b/src/xpath-util.js
@@ -126,7 +126,7 @@ export class XPathUtil {
 
     const parentBinding = XPathUtil.getParentBindingElement(boundElement);
     if(parentBinding){
-      return this.resolveInstance(parentBinding);
+		return this.resolveInstance(parentBinding, path);
     }
     return 'default';
   }

--- a/test/scoped-resolution.test.js
+++ b/test/scoped-resolution.test.js
@@ -362,11 +362,45 @@ describe('scoped resolution tests', () => {
     const el = await fixtureSync(html`
       <fx-fore>
         <fx-model>
-          <fx-instance src="/base/test/HD025278.xml" xpath-default-namespace="http://www.tei-c.org/ns/1.0"/>
+          <fx-instance>
+<data><ol><li><p>66</p></li><li><p>78</p></li></ol></data>
+</fx-instance>
+        </fx-model>
+        <fx-group ref="ol">
+          <fx-repeat ref="//li">
+            <template>
+              <fx-group ref="p">
+                <fx-control ref=".">
+                  <label>Breite2</label>
+                </fx-control>
+              </fx-group>
+            </template>
+          </fx-repeat>
+        </fx-group>
+      </fx-fore>
+    `);
+
+    // const model = el.querySelector('fx-fore fx-model');
+    await oneEvent(el, 'ready');
+
+    const controls = el.querySelectorAll('fx-control');
+    expect(controls.length).to.equal(2);
+
+    expect(controls[0].value).to.equal('66');
+    expect(controls[1].value).to.equal('78');
+  });
+
+	it('resolves group within repeat (external instance)', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore>
+        <fx-model>
+          <fx-instance src="/base/test/HD025278.xml" xpath-default-namespace="http://www.tei-c.org/ns/1.0"></fx-instance>
         </fx-model>
         <fx-group ref="teiHeader">
+{count(//*:msPart)}
           <fx-repeat ref=".//msPart">
             <template>
+---{name(.)}---
               <fx-group ref="physDesc/objectDesc/supportDesc/support/dimensions">
                 <fx-control ref="width">
                   <label>Breite2</label>
@@ -381,7 +415,8 @@ describe('scoped resolution tests', () => {
     // const model = el.querySelector('fx-fore fx-model');
     await oneEvent(el, 'ready');
 
-    const controls = el.querySelectorAll('fx-control');
+		const controls = el.querySelectorAll('fx-control');
+		console.log(el.outerHTML);
     expect(controls.length).to.equal(2);
 
     expect(controls[0].value).to.equal('66');


### PR DESCRIPTION
This fixes a recurring problem with repeats not really updating, causing the need for a full-page refresh every so often.

It also fixes a small oversight in the `DependencyNotifyingDomFacade` where the next sibling was not always returned correctly :sweat_smile:. With this we might wanna retest https://github.com/Jinntec/Fore/issues/125 :sweat_smile: :sweat_smile: :sweat_smile: :sweat_smile: 