### PR TITLE
Handle nested controls (loaded with src) with data-lists

### DIFF
--- a/src/ui/fx-control.js
+++ b/src/ui/fx-control.js
@@ -526,7 +526,8 @@ export default class FxControl extends XfAbstractControl {
    */
   _handleDataAttributeBinding() {
     const dataRefd = this.querySelector('[data-ref]');
-    if (dataRefd) {
+    // Handle nested fx-controls
+    if (dataRefd && dataRefd.closest('fx-control') === this) {
       this.boundList = dataRefd;
       const ref = dataRefd.getAttribute('data-ref');
       this._handleBoundWidget(dataRefd);

--- a/src/xpath-evaluation.js
+++ b/src/xpath-evaluation.js
@@ -1031,7 +1031,6 @@ const instance = (dynamicContext, string) => {
 
   const context = lookup.getDefaultContext();
   if (!context) {
-    debugger;
     return null;
   }
   return context;


### PR DESCRIPTION
In a nested control, the inner control should handle any data-refs. Not the outer one