### PR TITLE
Formalize dependencies on the 'index' function

### DIFF
--- a/src/DependentXPathQueries.js
+++ b/src/DependentXPathQueries.js
@@ -1,0 +1,51 @@
+export default class DependentXPathQueries {
+  constructor() {
+    /**
+     * @type {Set<string>}
+     */
+    this._xpaths = new Set();
+
+    this._parentDependencies = null;
+  }
+
+  /**
+   * Returns true if this Fore element should be refreshed if a result of an index function changes
+   *
+   * @returns {boolean}
+   */
+  isInvalidatedByIndexFunction() {
+    for (const xpath of this._xpaths) {
+      // TODO: this can be done a lot better with parsing / checking for function references
+      if (xpath.includes('index(')) {
+        return true;
+      }
+    }
+
+    // We can also depend on the index function if it was used in our ancestry
+    return !!this._parentDependencies?.isInvalidatedByIndexFunction();
+  }
+
+  /**
+   * Add an XPath to the dependencies
+   *
+   * @param {string} xpath the XPath to add
+   */
+  addXPath(xpath) {
+    this._xpaths.add(xpath);
+  }
+
+  /**
+   * Reset the dependencies on refresh
+   *
+   */
+  resetDependencies() {
+    this._xpaths.clear();
+  }
+
+  /**
+   * @param {DependentXPathQueries} deps
+   */
+  setParentDependencies(deps) {
+    this._parentDependencies = deps;
+  }
+}

--- a/src/ForeElementMixin.js
+++ b/src/ForeElementMixin.js
@@ -7,6 +7,7 @@ import {
 } from './xpath-evaluation.js';
 import getInScopeContext from './getInScopeContext.js';
 import { Fore } from './fore.js';
+import DependentXPathQueries from './DependentXPathQueries.js';
 
 /**
  * Mixin containing all general functions that are shared by all Fore element classes.
@@ -61,6 +62,9 @@ export default class ForeElementMixin extends HTMLElement {
      * @type {Map<string, import('./fx-var.js').FxVariable>}
      */
     this.inScopeVariables = new Map();
+
+    this._dependencies = new DependentXPathQueries();
+    this._dependencies.setParentDependencies(this.parent?.closest('[ref]')?._dependencies);
   }
 
   /**
@@ -103,6 +107,7 @@ export default class ForeElementMixin extends HTMLElement {
    * evaluation of fx-bind and UiElements differ in details so that each class needs it's own implementation.
    */
   evalInContext() {
+    this._dependencies.resetDependencies();
     // const inscopeContext = this.getInScopeContext();
     const model = this.getModel();
     if (!model) {
@@ -114,6 +119,7 @@ export default class ForeElementMixin extends HTMLElement {
     }
     if (this.hasAttribute('ref')) {
       inscopeContext = getInScopeContext(this.getAttributeNode('ref') || this, this.ref);
+      this._dependencies.addXPath(this.ref);
     }
     if (!inscopeContext && this.getModel().instances.length !== 0) {
       // ### always fall back to default context with there's neither a 'context' or 'ref' present

--- a/src/fx-fore.js
+++ b/src/fx-fore.js
@@ -484,6 +484,9 @@ export class FxFore extends HTMLElement {
   }
 
   // async refresh(force, changedPaths) {
+  /**
+   * @param {(boolean|{reason:'index-function'})} [force]fx-fore
+   */
   async refresh(force) {
     /*
 
@@ -578,7 +581,7 @@ export class FxFore extends HTMLElement {
 */
 
       if (this.inited) {
-        Fore.refreshChildren(this, true);
+        Fore.refreshChildren(this, force);
       }
       // console.timeEnd('refreshChildren');
     }
@@ -620,7 +623,7 @@ export class FxFore extends HTMLElement {
     for (const subFore of subFores) {
       // subFore.refresh(false, changedPaths);
       if (subFore.ready) {
-        await subFore.refresh(false);
+        await subFore.refresh(force);
       }
     }
     this.isRefreshing = false;

--- a/src/ui/fx-group.js
+++ b/src/ui/fx-group.js
@@ -91,7 +91,9 @@ class FxGroup extends FxContainer {
 
   async refresh(force) {
     super.refresh(force);
-    Fore.refreshChildren(this, force);
+    // Make the maybe filtered refresh an unconditional forced refresh: This fx-group changes the
+    // context item
+    Fore.refreshChildren(this, !!force);
   }
 }
 

--- a/src/ui/fx-repeat.js
+++ b/src/ui/fx-repeat.js
@@ -80,7 +80,7 @@ export class FxRepeat extends withDraggability(ForeElementMixin, false) {
     const rItems = this.querySelectorAll(':scope > fx-repeatitem');
     this.applyIndex(rItems[this.index - 1]);
 
-    this.getOwnerForm().refresh(true);
+    this.getOwnerForm().refresh({ reason: 'index-function' });
   }
 
   applyIndex(repeatItem) {


### PR DESCRIPTION
This prevents a potentioally expensive force refresh when the index function has changed its value (moving between repeat items). Replacing with a (force) refresh of anything _including and underneath_ something with an `index()` function