### PR TITLE
fix: do not make a relevant model item for nonexisting nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
       "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -3497,6 +3498,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -4758,6 +4760,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
       "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -5180,6 +5183,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -5753,6 +5757,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6978,6 +6983,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
       "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -9584,6 +9590,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9762,6 +9769,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -9913,7 +9921,6 @@
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -13389,6 +13396,7 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
       "integrity": "sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
@@ -18952,6 +18960,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.6.tgz",
       "integrity": "sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -20617,6 +20626,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21746,6 +21756,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22132,6 +22143,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -22928,6 +22940,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
       "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -25295,6 +25308,7 @@
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
           "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@babel/code-frame": "7.12.11",
             "@eslint/eslintrc": "^0.4.3",
@@ -26286,6 +26300,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
       "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -26704,6 +26719,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -27214,7 +27230,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -28109,6 +28126,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
       "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "peer": true,
       "requires": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -30042,6 +30060,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -30358,6 +30377,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -30468,8 +30488,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "eslint-rule-extender": {
       "version": "0.0.1",
@@ -32868,6 +32887,7 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
       "integrity": "sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
@@ -37041,6 +37061,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.6.tgz",
       "integrity": "sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -38340,7 +38361,8 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -39113,7 +39135,8 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "rollup": {
           "version": "4.45.1",
@@ -39423,6 +39446,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/src/fx-fore.js
+++ b/src/fx-fore.js
@@ -2016,6 +2016,14 @@ export class FxFore extends HTMLElement {
 
       const parsed = parseName(token);
 
+      if (!isValidName(parsed.localName)) {
+        // This did not result in a valid name. Stop.
+        console.warn(
+          `Creating node for the XPath ${xpath} failed because the part ${parsed.localName} is not a valid Name.`,
+        );
+        return;
+      }
+
       if (parsed.isAttribute) {
         if (!current) {
           const attr = ownerDoc.createAttribute(parsed.localName);
@@ -2023,14 +2031,6 @@ export class FxFore extends HTMLElement {
         }
         current.setAttribute(parsed.localName, '');
         continue;
-      }
-
-      if (!isValidName(parsed.localName)) {
-        // This did not result in a valid name. Stop.
-        console.warn(
-          `Creating node for the XPath ${xpath} failed because the part ${parsed.localName} is not a valid Name.`,
-        );
-        return;
       }
 
       const element = parsed.namespaceURI

--- a/src/fx-model.js
+++ b/src/fx-model.js
@@ -135,7 +135,10 @@ export class FxModel extends HTMLElement {
     if (fore?.createNodes && (node === null || node === undefined)) {
       const mi = new ModelItem(undefined, ref, null, null, instanceId, fore);
       mi.isSynthetic = true;
-      model.registerModelItem(mi);
+      // TODO: set the relevancy to false only if the node could not be created
+      mi.relevant = false;
+
+      // Do not register the model item. It may be exchanged later when create-nodes actually made the node
       return mi;
     }
     if (node === null || node === undefined) return null;
@@ -159,8 +162,10 @@ export class FxModel extends HTMLElement {
     }
 
     const isLensObject =
-        !!targetNode && typeof targetNode === 'object' &&
-        typeof targetNode.get === 'function' && typeof targetNode.set === 'function';
+      !!targetNode &&
+      typeof targetNode === 'object' &&
+      typeof targetNode.get === 'function' &&
+      typeof targetNode.set === 'function';
 
     // If ModelItem for same path exists, RETARGET it (node OR lens)
     if (path) {
@@ -182,12 +187,12 @@ export class FxModel extends HTMLElement {
     }
 
     const mi = new ModelItem(
-        path,
-        ref,
-        targetNode,
-        model.getBindForElement(targetNode),
-        instanceId,
-        fore,
+      path,
+      ref,
+      targetNode,
+      model.getBindForElement(targetNode),
+      instanceId,
+      fore,
     );
     mi.isSynthetic = true;
 
@@ -231,7 +236,8 @@ export class FxModel extends HTMLElement {
           const defInst = this.getDefaultInstance();
           if (defInst) {
             const t = (defInst.getAttribute && defInst.getAttribute('type')) || defInst.type;
-            bindings.default = t === 'json' ? defInst.getInstanceData() : defInst.getDefaultContext();
+            bindings.default =
+              t === 'json' ? defInst.getInstanceData() : defInst.getDefaultContext();
           }
         } catch (_e) {
           // ignore
@@ -734,14 +740,14 @@ export class FxModel extends HTMLElement {
 
     // Path lookup
     if (typeof nodeOrPath === 'string') {
-      const key = nodeOrPath.includes(':') ? nodeOrPath.substring(0, nodeOrPath.indexOf(':')) : nodeOrPath;
+      const key = nodeOrPath.includes(':')
+        ? nodeOrPath.substring(0, nodeOrPath.indexOf(':'))
+        : nodeOrPath;
       return this.modelItems.find(mi => mi.path === key) || null;
     }
 
     // Node/lens lookup
-    return (
-        this.modelItems.find(mi => mi.node === nodeOrPath || mi.lens === nodeOrPath) || null
-    );
+    return this.modelItems.find(mi => mi.node === nodeOrPath || mi.lens === nodeOrPath) || null;
   }
 
   /**
@@ -791,9 +797,9 @@ export class FxModel extends HTMLElement {
     // ### lookup in parent Fore if present (shared instances)
     if (!found) {
       const parentFore =
-          this.fore.parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE
-              ? this.fore.parentNode.host.closest('fx-fore')
-              : this.fore.parentNode.closest('fx-fore');
+        this.fore.parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+          ? this.fore.parentNode.host.closest('fx-fore')
+          : this.fore.parentNode.closest('fx-fore');
 
       if (parentFore) {
         const parentInstances = parentFore.getModel().instances;

--- a/src/fx-model.js
+++ b/src/fx-model.js
@@ -133,13 +133,8 @@ export class FxModel extends HTMLElement {
     const fore = model.formElement;
 
     if (fore?.createNodes && (node === null || node === undefined)) {
-      const mi = new ModelItem(undefined, ref, null, null, instanceId, fore);
-      mi.isSynthetic = true;
-      // TODO: set the relevancy to false only if the node could not be created
-      mi.relevant = false;
-
-      // Do not register the model item. It may be exchanged later when create-nodes actually made the node
-      return mi;
+      // Do not create the model item. It may be exchanged later when create-nodes actually made the node
+      return null;
     }
     if (node === null || node === undefined) return null;
 

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import {
-  html, fixtureSync, expect, elementUpdated, oneEvent,
-} from '@open-wc/testing';
+import { html, fixtureSync, expect, elementUpdated, oneEvent } from '@open-wc/testing';
 
 import '../index.js';
 
@@ -80,12 +78,14 @@ describe('group tests', () => {
             </data>
           </fx-instance>
 
-          <fx-submission id="s-load"
-                         method="post"
-                         url="#echo"
-                         ref="instance('data')"
-                         replace="instance"
-                         instance="default"></fx-submission>
+          <fx-submission
+            id="s-load"
+            method="post"
+            url="#echo"
+            ref="instance('data')"
+            replace="instance"
+            instance="default"
+          ></fx-submission>
         </fx-model>
 
         <fx-trigger id="t1">
@@ -121,14 +121,71 @@ describe('group tests', () => {
     const t1 = el.querySelector('#t1');
     t1.performActions();
 
-        setTimeout(() => group.refresh());
-        await oneEvent(group, 'enabled');
+    setTimeout(() => group.refresh());
+    await oneEvent(group, 'enabled');
 
-        expect(group.hasAttribute('relevant')).to.be.true;
+    expect(group.hasAttribute('relevant')).to.be.true;
 
-        const t2 = el.querySelector('#t2');
-        t2.performActions();
-        await oneEvent(group, 'disabled');
-        expect(group.hasAttribute('nonrelevant')).to.be.true;
+    const t2 = el.querySelector('#t2');
+    t2.performActions();
+    await oneEvent(group, 'disabled');
+    expect(group.hasAttribute('nonrelevant')).to.be.true;
+  });
+
+  it('groups that bind to something nonexistant do not get relevant when create-nodes is enabled and the node could not be created', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore create-nodes>
+        <fx-model>
+          <fx-instance>
+            <data>
+              <foo type="baz">bar</foo>
+            </data>
+          </fx-instance>
+        </fx-model>
+
+        <fx-group id="the-group" ref="foo/@type='not-baz'">
+          <h2>a section of content being non-relevant initiallly</h2>
+        </fx-group>
+      </fx-fore>
+    `);
+
+    await elementUpdated(el);
+    const group = el.querySelector('#the-group');
+    expect(group).to.exist;
+
+    expect(group.hasAttribute('relevant'), 'The group should not be relevant').to.be.false;
+    expect(group.hasAttribute('nonrelevant'), 'The group should be nonrelevant').to.be.true;
+
+    // Now make it relevant!
+  });
+
+  it('groups that bind to something nonexistant do not get relevant when create-nodes is enabled and the node can be created', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore create-nodes>
+        <fx-model>
+          <fx-instance>
+            <data>
+              <foo></foo>
+            </data>
+          </fx-instance>
+        </fx-model>
+
+        <fx-group id="the-group" ref="foo/bar">
+          <h2>
+            a section of content being non-relevant initiallly. But create-nodes fills it in right
+            away!
+          </h2>
+        </fx-group>
+      </fx-fore>
+    `);
+
+    await elementUpdated(el);
+    const group = el.querySelector('#the-group');
+    expect(group).to.exist;
+
+    expect(group.hasAttribute('relevant')).to.be.true;
+    expect(group.hasAttribute('nonrelevant')).to.be.false;
+
+    // Now make it relevant!
   });
 });


### PR DESCRIPTION
This would just make fx-groups w/o a nodeset relevant. Unexpected behaviour follows after