### PR TITLE
fix(create-nodes): allow setting the values of elements in createnodes

### DIFF
--- a/src/createNodes.js
+++ b/src/createNodes.js
@@ -82,26 +82,22 @@ function splitSteps(xpath) {
 }
 
 /**
- * @param {string} possibleAttributeTest
+ * Extract the operands for a value test. So `@type="xx"` -> (@type, 'xx') or `Value = "yy"` -> (Value, yy)
+ * @param {string} possibleValueTest
  */
-function extractAttributeTest(possibleAttributeTest) {
-  possibleAttributeTest = possibleAttributeTest.trim();
-  if (!possibleAttributeTest.startsWith('@')) {
-    return null;
-  }
-  const predicateRegex = /@(.*)\s*=\s*(['"])(.*)\2/g;
-  const match = predicateRegex.exec(possibleAttributeTest);
+function extractValueTest(possibleValueTest) {
+  possibleValueTest = possibleValueTest.trim();
+  const predicateRegex = /^\s*(@?[a-zA-Z0-9-_]*)\s*=\s*(['"])(.*)\2/g;
+  const match = predicateRegex.exec(possibleValueTest);
   if (match) {
-    // Yep, this has the form `@type="my-type"`
     return { name: match[1].trim(), value: match[3] };
   }
 
-  // This is of the form `@attr`
-  return { name: possibleAttributeTest.substring(1), value: null };
+  return null;
 }
 
 /**
- * @typedef {{form: 'attributes', found: {name: string, value: string}} | {form: 'nested-path', found: RawStep[]}} ParsedPredicate
+ * @typedef {{form: 'valueTest', found: {name: string, value: string|null}} | {form: 'nested-path', found: RawStep[]}} ParsedPredicate
  */
 
 /**
@@ -110,12 +106,12 @@ function extractAttributeTest(possibleAttributeTest) {
  * @returns {ParsedPredicate}
  */
 function parsePredicate(predicate) {
-  const attributeTest = extractAttributeTest(predicate);
-  if (attributeTest) {
-    // Yep, this has the form `@type="my-type"`
+  const valueTest = extractValueTest(predicate);
+  if (valueTest) {
+    // Yep, this has the form `@type="my-type"` or `type="my-type"
     return {
-      form: 'attributes',
-      found: attributeTest,
+      form: 'valueTest',
+      found: valueTest,
     };
   }
 
@@ -151,35 +147,37 @@ export default function createNodes(xpath, baseElement, foreElement) {
     const raw = token.trim();
 
     if (raw.startsWith('@')) {
-      const { name, value } = extractAttributeTest(raw);
+      const { name: rawName, value } = extractValueTest(raw) ?? { name: raw, value: null };
+      // Remove the abbreviated axis step
+      const name = rawName.substring(1);
 
       if (name.startsWith('*:')) {
-        return { isAttribute: true, namespaceURI: null, localName: name.substring(2) };
+        return { isValue: true, namespaceURI: null, localName: name.substring(2) };
       }
       if (name.includes(':')) {
         const [prefix, localName] = name.split(':');
         return {
-          isAttribute: true,
+          isValue: true,
           namespaceURI: prefix === '*' ? null : namespaceResolver(prefix) || null,
           localName,
           value,
         };
       }
-      return { isAttribute: true, namespaceURI: null, localName: name, value };
+      return { isValue: true, namespaceURI: null, localName: name, value };
     }
 
     if (raw.startsWith('*:')) {
-      return { isAttribute: false, namespaceURI: baseNamespace, localName: raw.substring(2) };
+      return { isValue: false, namespaceURI: baseNamespace, localName: raw.substring(2) };
     }
     if (raw.includes(':')) {
       const [prefix, localName] = raw.split(':');
       return {
-        isAttribute: false,
+        isValue: false,
         namespaceURI: prefix === '*' ? baseNamespace : namespaceResolver(prefix) || baseNamespace,
         localName,
       };
     }
-    return { isAttribute: false, namespaceURI: baseNamespace, localName: raw };
+    return { isValue: false, namespaceURI: baseNamespace, localName: raw };
   };
 
   const steps = splitSteps(xpath).filter(step => step.nameTest !== '.');
@@ -216,7 +214,7 @@ export default function createNodes(xpath, baseElement, foreElement) {
       };
     }
 
-    if (parsed.isAttribute) {
+    if (parsed.isValue) {
       if (!current) {
         const attr = ownerDoc.createAttribute(parsed.localName);
         attr.value = parsed.value;
@@ -250,17 +248,34 @@ export default function createNodes(xpath, baseElement, foreElement) {
       if (!parsedPredicate) {
         // This did not result in a valid name. Stop.
         console.warn(
-          `Creating node for the XPath ${xpath} failed because the part ${predicates} could not be processed.`,
+          `Creating node for the XPath ${xpath} failed because the part ${predicate} could not be processed.`,
         );
         return {
           action: 'abort',
         };
       }
-      if (parsedPredicate.form === 'attributes') {
-        const attrName = parsedPredicate.found.name.includes(':')
-          ? parsedPredicate.found.name.split(':')[1]
-          : parsedPredicate.found.name;
-        element.setAttribute(attrName, parsedPredicate.found.value);
+      if (parsedPredicate.form === 'valueTest') {
+        const isAttribute = parsedPredicate.found.name.startsWith('@');
+        if (isAttribute) {
+          const attrNameWithoutAxis = parsedPredicate.found.name.substring(1);
+          const attrName = attrNameWithoutAxis.includes(':')
+            ? attrNameWithoutAxis.split(':')[1]
+            : attrNameWithoutAxis;
+          element.setAttribute(attrName, parsedPredicate.found.value);
+        } else {
+          // direct value
+          const elementName = parseName(parsedPredicate.found.name);
+          if (!isValidName(elementName.localName)) {
+            console.warn(
+              `Creating node for the XPath ${xpath} failed because the part ${predicate} could not be processed.`,
+            );
+            return { action: 'abort' };
+          }
+          const valueElement = element.appendChild(
+            ownerDoc.createElementNS(elementName.namespaceURI, parsedPredicate.found.name),
+          );
+          valueElement.append(parsedPredicate.found.value);
+        }
       } else {
         const nestedPath = parsedPredicate.found;
         let subtree = element;

--- a/src/createNodes.js
+++ b/src/createNodes.js
@@ -87,7 +87,7 @@ function splitSteps(xpath) {
  */
 function extractValueTest(possibleValueTest) {
   possibleValueTest = possibleValueTest.trim();
-  const predicateRegex = /^\s*(@?[a-zA-Z0-9-_]*)\s*=\s*(['"])(.*)\2/g;
+  const predicateRegex = /^\s*(@?[a-zA-Z0-9-_:]*)\s*=\s*(['"])(.*)\2/g;
   const match = predicateRegex.exec(possibleValueTest);
   if (match) {
     return { name: match[1].trim(), value: match[3] };

--- a/test/createNodes.test.js
+++ b/test/createNodes.test.js
@@ -14,7 +14,7 @@ let foreElement = null;
 let baseElement = null;
 describe('createNodes', () => {
   beforeEach(async () => {
-    foreElement = await fixture(html`<fx-fore />`);
+    foreElement = await fixture(html`<fx-fore xmlns:foo="bar" />`);
 
     baseElement = new window.DOMParser().parseFromString(
       '<xml />',
@@ -138,6 +138,19 @@ describe('createNodes', () => {
 
       expect(result.outerHTML).to.equal(
         '<InvoiceLine><Item><AdditionalItemProperty><Name>RightType</Name><Value/></AdditionalItemProperty></Item></InvoiceLine>',
+      );
+    });
+
+    it('Can set values of namespaced elements in predicates', () => {
+      const result = createNodes(
+        `foo:InvoiceLine/foo:Item/foo:AdditionalItemProperty[foo:Name='RightType']/foo:Value`,
+        baseElement,
+        foreElement,
+      );
+      expect(result).to.not.equal(null, 'The result should not be null');
+
+      expect(result.outerHTML).to.equal(
+        '<InvoiceLine xmlns="bar"><Item><AdditionalItemProperty><Name>RightType</Name><Value/></AdditionalItemProperty></Item></InvoiceLine>',
       );
     });
   });

--- a/test/createNodes.test.js
+++ b/test/createNodes.test.js
@@ -94,6 +94,15 @@ describe('createNodes', () => {
     expect(result).to.equal(null, 'The result should be null');
   });
 
+  it('Does not set the values of elements outside of predicates', () => {
+    const result = createNodes(
+      `InvoiceLine/Item/AdditionalItemProperty/Name='RightType'`,
+      baseElement,
+      foreElement,
+    );
+    expect(result).to.equal(null, 'The result should be null');
+  });
+
   describe('recursive processing', () => {
     it('can make a path with new expressions in the predicate', () => {
       const xpath = 'a[b/c]';
@@ -117,6 +126,19 @@ describe('createNodes', () => {
       expect(result).to.not.equal(null, 'The result should not be null');
 
       expect(result.outerHTML).to.equal('<name><name attr="value"/></name>');
+    });
+
+    it('Can set values of elements in predicates', () => {
+      const result = createNodes(
+        `InvoiceLine/Item/AdditionalItemProperty[Name='RightType']/Value`,
+        baseElement,
+        foreElement,
+      );
+      expect(result).to.not.equal(null, 'The result should not be null');
+
+      expect(result.outerHTML).to.equal(
+        '<InvoiceLine><Item><AdditionalItemProperty><Name>RightType</Name><Value/></AdditionalItemProperty></Item></InvoiceLine>',
+      );
     });
   });
 });


### PR DESCRIPTION
And refactor a bit, process more as path steps, and see both attributes and elements as value tests

Fixes #362

## What does this change?

This fixes #362 by setting values for elements if the path refers to them

## How was this tested?

- [X] Unit tests (`npm test`) pass
- [X] Relevant Cypress e2e tests pass, or a new demo exercises the change
- [X] Linting (`npm run lint`) passes

## Related issues

Closes #362
