### PR TITLE
fix(package.json): make package consumable by bundlers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,19 @@ jobs:
               run: npm run build
             - name: Run tests
               run: npm test --headless
+    package:
+        name: Package is consumable by bundlers
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Use Node.js 22
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+            - name: Install dependencies
+              run: npm ci
+            - name: Verify published package
+              run: npm run verify:package
     cypress-run:
         runs-on: ubuntu-22.04
         steps:

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@
 # Declarative applications in plain HTML
 
 Fore lets you write data-driven front-end applications in a declarative way
-just using HTML5 Web Components. 
+just using HTML5 Web Components.
 
 ![todo](resources/images/todo-screen.png)
 
 [Source code](https://github.com/Jinntec/Fore/blob/960e093fadfbc96eb8514721fb7b53462567f1ec/demo/todo2.html) for above example just uses 53 lines of HTML.
 
 The use cases range from simple to complex forms to full single page
-applications. It can be used standalone or in conjunction with other web 
-components or frameworks. 
+applications. It can be used standalone or in conjunction with other web
+components or frameworks.
 
 By using the bare metal of the browser
 platform, Fore integrates well with any other library you might want to use in
@@ -109,8 +109,8 @@ To use whatever component in Fore you wrap it up in the generic
 </fx-control>
 ```
 
-The additional attributes `update-event` and `value-prop` allow to 
-customize the wiring of the widget you use. 
+The additional attributes `update-event` and `value-prop` allow to
+customize the wiring of the widget you use.
 
 ```
 <fx-control ref="checked" update-event="change" value-prop="checked">
@@ -150,8 +150,14 @@ Run `npm install @jinntec/fore` in your project to install it.
 If you're using a bundler (Vite, webpack, Rollup, ...), import it normally:
 
 ```js
-import '@jinntec/fore';
+import '@jinntec/fore';                     // production bundle, registers all elements
+import '@jinntec/fore/dev';                 // same, plus the Fore devtools panel
+import '@jinntec/fore/resources/fore.css';  // optional default styling
 ```
+
+Both entry points are the prebuilt, self-contained bundles from `dist/` — the same artefacts served
+from the CDN. `@jinntec/fore/dist/fore.js` and `@jinntec/fore/dist/fore-dev.js` are importable as
+explicit paths.
 
 If you're serving plain HTML without a bundler, reference the built bundle directly by its
 path inside `node_modules` (or copy `dist/fore.js` alongside your page):
@@ -181,7 +187,7 @@ entry point. This lists out running examples to learn and copy from.
 ## Running test suite
 
 `npm run test:watch`
- 
+
 Open your browser and goto to the URL mentioned in console output to start Karma and hit the button in the upper right to run the full test-suite. Will
 continously rerun the test suite while you're changing code.
 
@@ -238,12 +244,10 @@ The giants that made Fore possible:
 
 * past and current [XForms editors](https://www.w3.org/community/xformsusers/wiki/XForms_2.0) - not all brilliant ideas get traction and fame. Nevertheless a brilliantly worked out state engine.
 * [fontoXPath](https://github.com/FontoXML/fontoxpath) - without this wonderful XPath 3.1 implementation in the browser Fore has never been possible - period.
-* [depGraph](https://github.com/jriecken/dependency-graph) - finding this gem saved a big bunch of work. 
+* [depGraph](https://github.com/jriecken/dependency-graph) - finding this gem saved a big bunch of work.
 
 Thanks to all giants!
 
 ## License
 
 MIT — see [LICENSE](./LICENSE).
-
-

--- a/package.json
+++ b/package.json
@@ -2,32 +2,37 @@
   "name": "@jinntec/fore",
   "version": "4.1.1",
   "description": "Fore - declarative user interfaces in plain HTML",
-  "module": "./index.js",
+  "main": "./dist/fore.js",
+  "module": "./dist/fore.js",
+  "unpkg": "./dist/fore.js",
+  "jsdelivr": "./dist/fore.js",
+  "sideEffects": true,
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Jinntec/Fore"
+    "url": "git+https://github.com/Jinntec/Fore.git"
   },
   "directories": {
     "doc": "doc",
     "test": "test"
   },
   "exports": {
-    "import": "./index.js"
+    ".": {
+      "import": "./dist/fore.js"
+    },
+    "./dev": "./dist/fore-dev.js",
+    "./dist/*": "./dist/*",
+    "./resources/*": "./resources/*",
+    "./package.json": "./package.json"
   },
   "files": [
-    "index.js",
+    "dist/fore.js",
+    "dist/fore-dev.js",
     "resources/fore.css",
     "resources/vars.css",
-    "resources/toastify.css",
-    "src/**/*",
-    "dist/fore.js",
-    "dist/fore.js.map",
-    "dist/fore-dev.js",
-    "dist/fore-dev.js.map",
-    "!.DS_Store"
+    "resources/toastify.css"
   ],
   "dependencies": {
     "@jinntec/jinn-toast": "^1.0.5",
@@ -84,8 +89,9 @@
     "format:eslint": "eslint . --fix",
     "lint:prettier": "prettier \"**/*.js\" --check --ignore-path .eslintignore",
     "format:prettier": "prettier \"**/*.js\" --write --ignore-path .eslintignore",
+    "lint:pkg": "npx --yes publint@0.3",
     "docs": "wca src -f json --outFile fore-elements.json",
-    "lint": "npm run lint:eslint && npm run lint:prettier",
+    "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:pkg",
     "lint:types": "tsc",
     "format": "npm run format:eslint && npm run format:prettier",
     "test:watch": "karma start --auto-watch=true --single-run=false",
@@ -94,6 +100,7 @@
     "test:bs": "karma start karma.bs.config.js --coverage",
     "start:build": "cd dist && es-dev-server --open",
     "build": "rimraf dist && vite build --config vite.build.config.js && vite build --config vite.build-dev.config.js",
+    "verify:package": "bash scripts/verify-package.sh",
     "start": "vite --open --port 8090 --host",
     "preversion": "npm run test",
     "prepare": "npm run build",
@@ -120,6 +127,5 @@
   "engines": {
     "node": ">= 16.19.1"
   },
-  "prettier": "@open-wc/prettier-config",
-  "main": "index.js"
+  "prettier": "@open-wc/prettier-config"
 }

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Verifies that the published npm package can actually be consumed by a bundler,
+# which is what https://github.com/Jinntec/Fore/issues/370 regressed on.
+#
+# It packs the package exactly as `npm publish` would, installs the tarball into a
+# throwaway project, and runs `vite build` against the library's own documented
+# entry points. A green run means `import '@jinntec/fore'` works out of the box.
+#
+# Usage: npm run verify:package
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+WORK_DIR="$(mktemp -d)"
+TARBALL=""
+cleanup() {
+  [[ -n "$TARBALL" && -f "$ROOT_DIR/$TARBALL" ]] && rm -f "$ROOT_DIR/$TARBALL"
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+echo "== Building bundles =="
+npm run build
+
+echo "== Packing tarball =="
+# --ignore-scripts: we already built above; don't run `prepare` again.
+rm -f "$ROOT_DIR"/jinntec-fore-*.tgz
+npm pack --ignore-scripts >/dev/null
+TARBALL="$(cd "$ROOT_DIR" && ls -1 jinntec-fore-*.tgz)"
+echo "Packed $TARBALL"
+
+echo "== Static packaging lint (publint) =="
+# Not --strict: the remaining advisories are about shipping ESM as `.js` without a
+# top-level "type": "module", which bundlers (the supported consumers) handle fine.
+# publint still fails the build on real errors: a subpath pointing at a missing file.
+npx --yes publint@0.3
+
+echo "== Setting up throwaway consumer project in $WORK_DIR =="
+cd "$WORK_DIR"
+npm init -y >/dev/null
+npm install --no-audit --no-fund --silent "$ROOT_DIR/$TARBALL" vite@^7
+
+cat > main.js <<'EOF'
+// Every entry point the README/docs tell consumers to use.
+import '@jinntec/fore';
+import '@jinntec/fore/dev';
+import '@jinntec/fore/dist/fore.js';
+import '@jinntec/fore/dist/fore-dev.js';
+import '@jinntec/fore/resources/fore.css';
+EOF
+
+cat > index.html <<'EOF'
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>fore package smoke test</title></head>
+  <body>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>
+EOF
+
+echo "== vite build (bundler resolution + pre-transform) =="
+npx vite build --logLevel warn
+
+echo "== Node ESM resolution of every exported subpath =="
+node --input-type=module <<'EOF'
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const specifiers = [
+  '@jinntec/fore',
+  '@jinntec/fore/dev',
+  '@jinntec/fore/dist/fore.js',
+  '@jinntec/fore/dist/fore-dev.js',
+  '@jinntec/fore/resources/fore.css',
+  '@jinntec/fore/resources/vars.css',
+  '@jinntec/fore/resources/toastify.css',
+  '@jinntec/fore/package.json',
+];
+
+let failed = 0;
+for (const specifier of specifiers) {
+  try {
+    const resolved = fileURLToPath(import.meta.resolve(specifier));
+    if (!existsSync(resolved)) {
+      console.error(`  MISSING  ${specifier} -> ${resolved} (not in tarball)`);
+      failed++;
+    } else {
+      console.log(`  ok       ${specifier}`);
+    }
+  } catch (error) {
+    console.error(`  BLOCKED  ${specifier} -> ${error.message}`);
+    failed++;
+  }
+}
+process.exit(failed ? 1 : 0);
+EOF
+
+echo
+echo "== Package verified: bundler + Node resolution both succeed =="


### PR DESCRIPTION
Without any changes. Fixes #370

## What does this change?

This adds a few overrides for imports, so vite apps can install Fore without any tricks with imports.

## How was this tested?

A new action is added that verifies the app can just be loaded.

## Related issues

Closes #370
