### PR TITLE
fix(fx-send): recompute facets after submit-done on replace="instance"

### DIFF
--- a/src/actions/fx-send.js
+++ b/src/actions/fx-send.js
@@ -14,6 +14,9 @@ class FxSend extends AbstractAction {
     this.value = '';
     this.url = null;
     this.target = null;
+    // set in perform() when a replace="instance" response landed while inside an action
+    // chain; consumed in actionPerformed() - see there.
+    this._deferInstanceReplaceUpdate = false;
   }
 
   connectedCallback() {
@@ -86,37 +89,50 @@ class FxSend extends AbstractAction {
       submission.parameters.set('target', resolved);
     }
 
-    // Capture before submit.submit() runs: fx-submission#_handleResponse() itself already
-    // runs the full updateModel()+refresh(true) cycle for a replace="instance" response,
-    // unless the model wasn't inited yet (see the `model.inited` guard there) - in that one
-    // case it skips its own cycle and we still need to do it below. Reading `inited` now (not
-    // after submit()) avoids mistaking "became inited during this very submit()" for "was
-    // already inited", which would wrongly skip the only cycle that ran.
-    const modelWasInited = this.getModel().inited;
     await submission.submit();
     if (submission.replace === 'instance') {
-      if (!modelWasInited) {
-        this.getModel().updateModel();
-        // todo: this bypasses observers...
-        this.getOwnerForm().refresh(true); // whole instance changes - full refresh necessary
-        // this.getOwnerForm().addToBatchedNotifications(this.getOwnerForm());
-      }
-      // needsUpdate is set (below, via actionPerformed override) so the undo hook records
-      // this replace as an undo step - it is NOT read by the default actionPerformed cycle
-      // here, since that would run a second, redundant recalculate/revalidate/refresh(false)
-      // on top of the full refresh(true) already done (either just above, or inside
-      // fx-submission#_handleResponse)
+      // Mark the replace as an undo step (the hook in _finalizePerform() reads needsUpdate).
       this.needsUpdate = true;
+
+      if (submission._updateCycleDeferredToChain) {
+        // _handleResponse() replaced an instance while running inside this action chain and
+        // handed the update cycle to us: own it from actionPerformed(), which fires AFTER
+        // the submit-done / submit-error child actions so their model changes are folded
+        // into the same rebuild/recalculate (issue #373).
+        submission._updateCycleDeferredToChain = false;
+        this._deferInstanceReplaceUpdate = true;
+      } else if (!this.getModel().inited) {
+        // Model never came up during submit(), so _handleResponse() skipped its
+        // inited-guarded cycle and nothing else will run one - do it here.
+        this.getModel().updateModel();
+        this.getOwnerForm().refresh(true); // whole instance changed - full refresh
+      }
+      // else (submit-error / validation failure / stub): nothing was swapped, so no
+      // rebuild is owed; super.actionPerformed() still runs the normal light cycle.
     }
     // if not of type fx-submission signal error
   }
 
   actionPerformed() {
-    // the instance-replace branch above already ran the full update+refresh cycle itself;
-    // skip the default gated cycle (see the comment at the needsUpdate assignment) while
-    // still calling dispatchActionPerformed() - the generic undo commit/discard hook in
-    // _finalizePerform() runs independently of this override and needs nothing extra here
-    this.dispatchActionPerformed();
+    // A replace="instance" response swaps a whole instance root; like fx-reset / fx-replace,
+    // fx-send owns the model update cycle for it. Running it HERE (not inside
+    // fx-submission#_handleResponse()) means the submit-done / submit-error child actions
+    // have already executed and recorded their model changes, so a full recalculate folds
+    // them in - previously those changes were stranded and dependent facets
+    // (relevant/readonly/calculate) never recomputed (issue #373).
+    if (this._deferInstanceReplaceUpdate) {
+      this._deferInstanceReplaceUpdate = false;
+      const model = this.getModel();
+      model.changed = []; // whole instance replaced - recompute the full graph
+      model.updateModel();
+      this.getOwnerForm().refresh(true);
+      this.dispatchActionPerformed();
+      return;
+    }
+    // submit-error / validation failure / non-instance replace: nothing was swapped, so no
+    // rebuild is owed here. A submit-done / submit-error child action's own model change
+    // (if any) still gets flushed through the normal deferred-update path.
+    super.actionPerformed();
   }
 
   _emitToChannel() {

--- a/src/fx-submission.js
+++ b/src/fx-submission.js
@@ -1,4 +1,5 @@
 import { Fore } from './fore.js';
+import { FxFore } from './fx-fore.js';
 import { Relevance } from './relevance.js';
 import { evaluateXPath } from './xpath-evaluation.js';
 import ForeElementMixin from './ForeElementMixin.js';
@@ -107,6 +108,9 @@ export class FxSubmission extends ForeElementMixin {
   }
 
   async submit() {
+    // Set by _handleResponse() when it hands the model update cycle to the surrounding
+    // action chain (see there); read + cleared by fx-send right after submit() resolves.
+    this._updateCycleDeferredToChain = false;
     await Fore.dispatch(this, 'submit', { submission: this });
     await this._submit();
   }
@@ -567,20 +571,20 @@ export class FxSubmission extends ForeElementMixin {
 
       // Skip any refreshes if the model is not yet inited
       if (this.model.inited) {
-        // Rebuild model items / binds against the new instance root
-        this.model.updateModel();
-
         // ✅ treat instance replacement as a structural change
-        const fore =
-          (typeof this.getOwnerForm === 'function' && this.getOwnerForm()) ||
-          this.closest('fx-fore') ||
-          this.getModel()?.parentNode;
+        const fore = this.getOwnerForm();
+        fore.someInstanceDataStructureChanged = true;
 
-        if (fore) {
-          fore.someInstanceDataStructureChanged = true;
-          if (typeof fore.scanForNewTemplateExpressionsNextRefresh === 'function') {
-            fore.scanForNewTemplateExpressionsNextRefresh();
-          }
+        // Inside an action chain the triggering fx-send owns the rebuild/recalculate/refresh
+        // cycle and runs it from its actionPerformed() - which fires AFTER the
+        // submit-done / submit-error child actions, so any model changes they make land in
+        // the same cycle (issue #373). This mirrors how fx-reset / fx-replace own theirs.
+        // A standalone submit() (direct call, or event="ready" before an action chain
+        // exists) has no such owner, so run the cycle here.
+        if (FxFore.outermostHandler) {
+          this._updateCycleDeferredToChain = true;
+        } else {
+          this.model.updateModel();
           // ✅ IMPORTANT: await, otherwise tests/action-pipeline can out-run the refresh
           await fore.refresh(true);
         }

--- a/test/issue-373-facet-recompute-after-submit-done.test.js
+++ b/test/issue-373-facet-recompute-after-submit-done.test.js
@@ -1,0 +1,171 @@
+/* eslint-disable no-unused-expressions */
+import { html, fixtureSync, expect, oneEvent, waitUntil } from '@open-wc/testing';
+
+import '../index.js';
+
+/**
+ * Issue #373 — a `relevant` / `readonly` expression on a node whose value is toggled
+ * by `fx-setvalue` children of an `fx-submission` (`event="submit"` /
+ * `event="submit-done"`) stays stale after the submission completes.
+ *
+ * The `submit-done` setvalue runs *after* fx-submission has already done its own
+ * updateModel()+refresh() for a `replace="instance"` response. `fx-send` holds the
+ * outermost-handler slot for the whole async `submit()`, so that late change is only
+ * deferred back to `fx-send` — whose `actionPerformed()` override used to swallow it.
+ * The changed ModelItem was left in `model.changed`, its facets never recomputed.
+ */
+describe('issue #373 - facet recompute after submit-done setvalue', () => {
+  it('records a dependency edge for a self-referential relevant expr (sanity)', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore>
+        <fx-model>
+          <fx-instance id="ui"
+            ><data><busy>false</busy></data></fx-instance
+          >
+          <fx-bind ref="instance('ui')/busy" relevant=". = 'true'"></fx-bind>
+        </fx-model>
+        <fx-group id="loading" ref="instance('ui')/busy"><p>Loading</p></fx-group>
+      </fx-fore>
+    `);
+    await oneEvent(el, 'refresh-done');
+
+    const graph = el.querySelector('fx-model').mainGraph;
+    const relevantKey = Object.keys(graph.outgoingEdges).find(n => n.endsWith(':relevant'));
+    const base = relevantKey.replace(/:relevant$/, '');
+    expect(graph.dependantsOf(base, false)).to.include(relevantKey);
+  });
+
+  it('recomputes a self-referential relevant on a plain fx-setvalue', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore>
+        <fx-model>
+          <fx-instance id="ui"
+            ><data><busy>false</busy></data></fx-instance
+          >
+          <fx-bind ref="instance('ui')/busy" relevant=". = 'true'"></fx-bind>
+        </fx-model>
+        <fx-group id="loading" ref="instance('ui')/busy"><p>Loading</p></fx-group>
+        <fx-trigger id="go-busy"
+          ><button>busy</button>
+          <fx-setvalue ref="instance('ui')/busy">true</fx-setvalue></fx-trigger
+        >
+        <fx-trigger id="go-idle"
+          ><button>idle</button>
+          <fx-setvalue ref="instance('ui')/busy">false</fx-setvalue></fx-trigger
+        >
+      </fx-fore>
+    `);
+    await oneEvent(el, 'refresh-done');
+    const group = el.querySelector('#loading');
+    expect(group.hasAttribute('nonrelevant'), 'initially nonrelevant').to.be.true;
+
+    await el.querySelector('#go-busy').performActions();
+    await waitUntil(() => group.hasAttribute('relevant'), 'relevant once busy=true');
+
+    await el.querySelector('#go-idle').performActions();
+    await waitUntil(() => group.hasAttribute('nonrelevant'), 'nonrelevant once busy=false');
+  });
+
+  it('recomputes relevant after a submit-done setvalue resets the bound node', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore>
+        <fx-model>
+          <fx-instance id="ui"
+            ><data><busy>false</busy></data></fx-instance
+          >
+          <fx-instance id="recipes"
+            ><data><placeholder /></data
+          ></fx-instance>
+          <fx-bind ref="instance('ui')/busy" relevant=". = 'true'"></fx-bind>
+
+          <fx-submission
+            id="s-load"
+            method="get"
+            url="/base/test/answer.xml"
+            replace="instance"
+            instance="recipes"
+          >
+            <fx-setvalue ref="instance('ui')/busy" event="submit">true</fx-setvalue>
+            <fx-setvalue ref="instance('ui')/busy" event="submit-done">false</fx-setvalue>
+          </fx-submission>
+        </fx-model>
+
+        <fx-group id="loading" ref="instance('ui')/busy"><p>Loading</p></fx-group>
+        <fx-trigger id="load"
+          ><button>load</button> <fx-send submission="s-load"></fx-send
+        ></fx-trigger>
+      </fx-fore>
+    `);
+    await oneEvent(el, 'refresh-done');
+
+    const group = el.querySelector('#loading');
+    const busy = () =>
+      el.querySelector('fx-instance#ui').instanceData.documentElement.querySelector('busy')
+        .textContent;
+
+    expect(group.hasAttribute('nonrelevant'), 'initially nonrelevant').to.be.true;
+
+    const sub = el.querySelector('#s-load');
+    el.querySelector('#load').performActions();
+    await oneEvent(sub, 'submit-done');
+
+    await waitUntil(() => busy() === 'false', 'busy data resets to false');
+    await waitUntil(
+      () => group.hasAttribute('nonrelevant'),
+      () =>
+        `group stuck relevant after load; busy="${busy()}" ` +
+        `relevant=${group.hasAttribute('relevant')} nonrelevant=${group.hasAttribute('nonrelevant')}`,
+    );
+    expect(group.hasAttribute('relevant'), 'group is not relevant').to.be.false;
+  });
+
+  it('also recomputes a cross-referential readonly after submit-done', async () => {
+    const el = await fixtureSync(html`
+      <fx-fore>
+        <fx-model>
+          <fx-instance id="ui"
+            ><data><busy>false</busy><name>x</name></data></fx-instance
+          >
+          <fx-instance id="recipes"
+            ><data><placeholder /></data
+          ></fx-instance>
+          <fx-bind ref="instance('ui')/name" readonly="instance('ui')/busy = 'true'"></fx-bind>
+
+          <fx-submission
+            id="s-load2"
+            method="get"
+            url="/base/test/answer.xml"
+            replace="instance"
+            instance="recipes"
+          >
+            <fx-setvalue ref="instance('ui')/busy" event="submit">true</fx-setvalue>
+            <fx-setvalue ref="instance('ui')/busy" event="submit-done">false</fx-setvalue>
+          </fx-submission>
+        </fx-model>
+
+        <fx-input id="nameField" ref="instance('ui')/name"></fx-input>
+        <fx-trigger id="load2"
+          ><button>load</button> <fx-send submission="s-load2"></fx-send
+        ></fx-trigger>
+      </fx-fore>
+    `);
+    await oneEvent(el, 'refresh-done');
+
+    const model = el.querySelector('fx-model');
+    const nameMI = () =>
+      model.getModelItem(
+        el.querySelector('fx-instance#ui').instanceData.documentElement.querySelector('name'),
+      );
+
+    expect(nameMI().readonly, 'initially not readonly').to.be.false;
+
+    const sub = el.querySelector('#s-load2');
+    el.querySelector('#load2').performActions();
+    await oneEvent(sub, 'submit-done');
+
+    await waitUntil(
+      () => nameMI() && nameMI().readonly === false,
+      () => `name modelItem stuck readonly=${nameMI() && nameMI().readonly}`,
+    );
+  });
+});


### PR DESCRIPTION
## What does this change?
A replace="instance" submission ran its updateModel()+refresh() inside _handleResponse(), before submit-done/submit-error fire. Changes those child actions made (e.g. resetting a `busy` flag) then had no cycle to process them, so relevant/readonly/calculate kept their pre-submit values.

fx-send now owns that cycle and runs it from actionPerformed(), after the child actions - like fx-reset/fx-replace do. _handleResponse() still runs it for a standalone submit(). The issue's "self-referential expression" diagnosis is incorrect - the dependency edge is recorded fine.



## How was this tested?

- [x] Unit tests (`npm test`) pass
- [x] Relevant Cypress e2e tests pass, or a new demo exercises the change
- [x] Linting (`npm run lint`) passes

## Related issues

Closes #373
